### PR TITLE
Move badge logic to base class to support all lists

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/lists/BaseListItem.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/lists/BaseListItem.java
@@ -3,11 +3,11 @@ package org.dominokit.domino.ui.lists;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.HTMLHeadingElement;
 import elemental2.dom.HTMLParagraphElement;
-import elemental2.dom.Text;
+
+import org.dominokit.domino.ui.badges.Badge;
 import org.dominokit.domino.ui.utils.BaseDominoElement;
 import org.dominokit.domino.ui.utils.DominoElement;
 import org.dominokit.domino.ui.utils.ElementUtil;
-import org.dominokit.domino.ui.utils.TextNode;
 
 import static java.util.Objects.isNull;
 import static org.jboss.gwt.elemento.core.Elements.h;
@@ -58,5 +58,18 @@ public abstract class BaseListItem<E extends HTMLElement, T extends BaseListItem
 
     public DominoElement<HTMLParagraphElement> getBody() {
         return DominoElement.of(body);
+    }
+
+    public T appendChild(Badge badge) {
+        return appendChild(badge, true);
+    }
+
+    public T appendChild(Badge badge, boolean first) {
+        if (first) {
+            insertFirst(badge);
+        } else {
+            appendChild(badge.asElement());
+        }
+        return (T) this;
     }
 }

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/lists/SimpleListItem.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/lists/SimpleListItem.java
@@ -2,7 +2,6 @@ package org.dominokit.domino.ui.lists;
 
 import elemental2.dom.HTMLLIElement;
 import elemental2.dom.Node;
-import org.dominokit.domino.ui.badges.Badge;
 import org.dominokit.domino.ui.style.Color;
 import org.dominokit.domino.ui.utils.HasBackground;
 import org.jboss.gwt.elemento.core.IsElement;
@@ -13,7 +12,7 @@ import static org.jboss.gwt.elemento.core.Elements.li;
 public class SimpleListItem extends BaseListItem<HTMLLIElement, SimpleListItem> implements HasBackground<SimpleListItem> {
 
     private String style;
-    private HTMLLIElement element= li()
+    private HTMLLIElement element = li()
             .css(ListStyles.LIST_GROUP_ITEM)
             .asElement();
 
@@ -54,20 +53,6 @@ public class SimpleListItem extends BaseListItem<HTMLLIElement, SimpleListItem> 
 
     public SimpleListItem setText(String content) {
         setBodyText(content);
-        return this;
-    }
-
-    public SimpleListItem appendChild(Badge badge){
-        appendChild(badge, true);
-        return this;
-    }
-
-    public SimpleListItem appendChild(Badge badge, boolean first){
-        if(first) {
-            insertFirst(badge);
-        }else{
-            appendChild(badge.asElement());
-        }
         return this;
     }
 


### PR DESCRIPTION
On simple list items the label is wrapped correctly when adding badges on list items not. So this PR moves the logic to deal with badges from simple list to base class.