### PR TITLE
Take care of response type reading response text

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/upload/FileItem.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/upload/FileItem.java
@@ -352,7 +352,9 @@ public class FileItem extends BaseDominoElement<HTMLDivElement, FileItem> {
     private String getErrorMessage() {
         if (errorMessage != null)
             return errorMessage;
-        return request.responseText.isEmpty() ? "Error while sending request" : request.responseText;
+        
+        final boolean hasErrorText = request.responseType != null && (request.responseType.isEmpty() || request.responseType.equals("text")) && !request.responseText.isEmpty();
+        return hasErrorText ? request.responseText : "Error while sending request";
     }
 
     public void invalidate(String message) {


### PR DESCRIPTION
Response text can be readed when response type is empty string or "text".
See https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseText

Fix #320