### PR TITLE
Eventleave iexplorer problem

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/upload/FileUpload.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/upload/FileUpload.java
@@ -1,6 +1,8 @@
 package org.dominokit.domino.ui.upload;
 
 import elemental2.dom.*;
+import jsinterop.base.Js;
+
 import org.dominokit.domino.ui.grid.Column;
 import org.dominokit.domino.ui.grid.Row;
 import org.dominokit.domino.ui.icons.BaseIcon;
@@ -80,7 +82,8 @@ public class FileUpload extends BaseDominoElement<HTMLDivElement, FileUpload> im
             evt.preventDefault();
         });
         formElement.addEventListener("dragleave", evt -> {
-            removeHover();
+            if( isFormUploadElement(evt.target) )
+                removeHover();
             evt.stopPropagation();
             evt.preventDefault();
         });
@@ -99,6 +102,11 @@ public class FileUpload extends BaseDominoElement<HTMLDivElement, FileUpload> im
         Notification.createWarning(errorMessage).show();
     }
 
+    private boolean isFormUploadElement(EventTarget target) {
+    	HTMLElement element = Js.uncheckedCast(target);
+    	return element == formElement.element();
+    }
+    
     private void addHover() {
         formElement.style().add("file-upload-hover");
     }

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/public/css/style.css
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/public/css/style.css
@@ -3821,6 +3821,13 @@ a.disabled {
     font-size: 80px;
 }
 
+.file-upload .file-upload-message, .file-upload .file-upload-message-icon {
+    pointer-events: auto;
+}
+.file-upload-hover .file-upload-message, .file-upload-hover .file-upload-message-icon {
+    pointer-events: none;
+}
+
 .domino-file-preview {
     display: inline-block;
     height: 200px;


### PR DESCRIPTION
Only consider the "dragleave" event when leaving the main area of the file upload.

Fix for #345 and keep pointer events disabled