### PR TITLE
Simplify apt jar and dependencies.

### DIFF
--- a/domino-ui-tools/mdi-icons-processor/pom.xml
+++ b/domino-ui-tools/mdi-icons-processor/pom.xml
@@ -30,6 +30,20 @@
         <dependency>
             <groupId>org.dominokit.jackson</groupId>
             <artifactId>jackson-apt</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.elemental2</groupId>
+                    <artifactId>elemental2-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.gwtproject.i18n</groupId>
+                    <artifactId>gwt-cldr</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.gwtproject.i18n</groupId>
+                    <artifactId>gwt-datetimeformat</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.dominokit.jackson</groupId>
@@ -42,4 +56,65 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>javax.annotation:javax.annotation-api</exclude>
+                                    <exclude>org.dominokit:domino-ui-shared</exclude>
+                                    <exclude>org.dominokit.jackson:jackson-apt-processor</exclude>
+
+                                    <exclude>com.google.code.findbugs:jsr305</exclude>
+                                    <exclude>com.google.j2objc:j2objc-annotations</exclude>
+                                    <exclude>com.google.errorprone:error_prone_annotations</exclude>
+                                </excludes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com</pattern>
+                                    <shadedPattern>dominoui.shaded.com</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache</pattern>
+                                    <shadedPattern>dominoui.shaded.org.apache</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <createSourcesJar>true</createSourcesJar>
+                            <filters>
+                                <filter>
+                                    <artifact>org.dominokit.jackson:jackson-apt</artifact>
+                                    <excludes>
+                                        <exclude>**/*.java</exclude>
+                                        <exclude>**/*.gwt.xml</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.dominokit.jackson:jackson-super</artifact>
+                                    <excludes>
+                                        <exclude>**/*.java</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
See https://github.com/google/auto/tree/master/common#processor-resilience

The basic idea is to keep the apt jar as simple as possible, and
avoid external depenencies or classes that might conflict on the
classpath of the code being compiles with this processor. On Gradle
or some other build tool we can rely on classpaths not getting mixed,
but it is riskier in maevn, so we need to take care not to have
some library version in this processor break another processor or
vice versa, or to have some dependency here force another library
to be updated or vice versa.