### PR TITLE
Include shared sources in jar so j2cl can handle it

### DIFF
--- a/domino-ui-shared/pom.xml
+++ b/domino-ui-shared/pom.xml
@@ -15,4 +15,11 @@
     <name>domino-ui-shared</name>
 
 
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+            </resource>
+        </resources>
+    </build>
 </project>


### PR DESCRIPTION
I understand that j2cl should never actually need these classes, but in order to strip and transpile domino-ui.jar the way that the maven plugin does it today, we have to have these one way or another. Since the jar is so tiny, I don't think adding sources is an issue?