### PR TITLE
Fixed an issue with validate().isValid() and illegal Token in NumberBox

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/forms/NumberBox.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/forms/NumberBox.java
@@ -20,10 +20,23 @@ public abstract class NumberBox<T extends NumberBox<T, E>, E extends Number> ext
 
     public NumberBox(String label) {
         super("tel", label);
+        addInputStringValidator();
         addMaxValueValidator();
         addMinValueValidator();
         setAutoValidation(true);
         enableFormatting();
+    }
+
+    private void addInputStringValidator() {
+        addValidator(() -> {
+            String inputValue = getInputElement().element().value;
+            try {
+                double parsed = getNumberFormat().parse(inputValue);
+            } catch (NumberFormatException e) {
+                return ValidationResult.invalid(getInvalidFormatMessage());
+            }
+            return ValidationResult.valid();
+        });
     }
 
     private void addMaxValueValidator() {


### PR DESCRIPTION
Calling `BigDecimalBox.validate().isValid()` on an input field, that contains an illegal token (NaN) will return true - which is, in this case, definitiv wrong.

This PR adds another validation to the `NumberBox` super class which checks if an illegal token is entered.