### PR TITLE
improved split panel size adjustment

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/BaseSplitPanel.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/BaseSplitPanel.java
@@ -1,7 +1,9 @@
 package org.dominokit.domino.ui.splitpanel;
 
 import elemental2.dom.HTMLDivElement;
+import org.dominokit.domino.ui.style.Calc;
 import org.dominokit.domino.ui.style.ColorScheme;
+import org.dominokit.domino.ui.style.Unit;
 import org.dominokit.domino.ui.utils.BaseDominoElement;
 import org.dominokit.domino.ui.utils.DominoElement;
 
@@ -26,31 +28,10 @@ abstract class BaseSplitPanel<T extends BaseSplitPanel<T,S>, S extends BaseSplit
 
     private void updatePanelsSize() {
         double mainPanelSize = getSize();
-
-        double splittersSize = calculateSplittersSize();
-        double maxAllowed = mainPanelSize - splittersSize;
-        double totalSizePercent = splittersSize / mainPanelSize;
-
-        double totalSize = splittersSize;
         for (SplitPanel panel : panels) {
             double panelSize = getPanelSize(panel);
-            int sizePercent = new Double((panelSize / mainPanelSize) * 100).intValue();
-
-            setPanelSize(panel, sizePercent + "%");
-            panelSize = getPanelSize(panel);
-
-            if (totalSize + panelSize >= maxAllowed) {
-                if (totalSize < maxAllowed) {
-                    double newSizehPercent = 100 - totalSizePercent;
-                    setPanelSize(panel, "calc(" + newSizehPercent + "% - " + splittersSize + "px)");
-                } else {
-                    setPanelSize(panel,0 + "%");
-                }
-                totalSize = maxAllowed;
-            } else {
-                totalSize += panelSize;
-            }
-            totalSizePercent += sizePercent;
+            double sizePercent = (panelSize / mainPanelSize) * 100;
+            setPanelSize(panel, Calc.sub(Unit.percent.of(sizePercent), Unit.px.of(splitterSize / 2 * (panels.size() - 1))));
         }
     }
 
@@ -96,6 +77,16 @@ abstract class BaseSplitPanel<T extends BaseSplitPanel<T,S>, S extends BaseSplit
         this.splitterSize = size;
         splitters.forEach(hSplitter -> hSplitter.setSize(size));
         return (T) this;
+    }
+
+    @Override
+    public int getSplitterSize() {
+        return splitterSize;
+    }
+
+    @Override
+    public int numberOfPanels() {
+        return panels.size();
     }
 
     @Override

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/BaseSplitPanel.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/BaseSplitPanel.java
@@ -31,20 +31,12 @@ abstract class BaseSplitPanel<T extends BaseSplitPanel<T,S>, S extends BaseSplit
         for (SplitPanel panel : panels) {
             double panelSize = getPanelSize(panel);
             double sizePercent = (panelSize / mainPanelSize) * 100;
-            setPanelSize(panel, Calc.sub(Unit.percent.of(sizePercent), Unit.px.of(splitterSize / 2 * (panels.size() - 1))));
+            setPanelSize(panel, Calc.sub(Unit.percent.of(sizePercent), Unit.px.of(panel.isFirst() || panel.isLast() ? splitterSize / 2 : splitterSize)));
         }
     }
 
     protected abstract double getPanelSize(SplitPanel panel);
     protected abstract void setPanelSize(SplitPanel panel, String size);
-
-    private double calculateSplittersSize() {
-        double totalSize = 0;
-        for (S splitter : splitters) {
-            totalSize += splitter.getSize();
-        }
-        return totalSize;
-    }
 
     public T appendChild(SplitPanel panel) {
         panels.add(panel);
@@ -55,7 +47,13 @@ abstract class BaseSplitPanel<T extends BaseSplitPanel<T,S>, S extends BaseSplit
             splitters.add(splitter);
             element.appendChild(splitter);
             element.appendChild(panel);
+
+            SplitPanel secondLast = panels.get(panels.size() - 1);
+            secondLast.setLast(false);
+            panel.setLast(true);
+
         } else {
+            panel.setFirst(true);
             element.appendChild(panel);
         }
         return (T) this;
@@ -82,11 +80,6 @@ abstract class BaseSplitPanel<T extends BaseSplitPanel<T,S>, S extends BaseSplit
     @Override
     public int getSplitterSize() {
         return splitterSize;
-    }
-
-    @Override
-    public int numberOfPanels() {
-        return panels.size();
     }
 
     @Override

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/BaseSplitter.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/BaseSplitter.java
@@ -75,10 +75,11 @@ abstract class BaseSplitter<T extends BaseSplitter<?>> extends BaseDominoElement
     private void resize(SplitPanel first, SplitPanel second, double currentPosition, HasSize mainPanel) {
         double diff = currentPosition - initialStartPosition;
 
-        double firstSize = this.firstSize + diff;
-        double secondSize = this.secondSize - diff;
-        double firstPercent = ((firstSize / fullSize) * 100);
-        double secondPercent = ((secondSize / fullSize) * 100);
+        double firstSizeDiff = first.isFirst() ? this.firstSize + diff + (double) mainPanel.getSplitterSize() / 2 : this.firstSize + diff + mainPanel.getSplitterSize();
+        double secondSizeDiff = second.isLast() ? this.secondSize - diff + (double) mainPanel.getSplitterSize() / 2 :  this.secondSize - diff + mainPanel.getSplitterSize();
+
+        double firstPercent = (firstSizeDiff / fullSize * 100);
+        double secondPercent = (secondSizeDiff / fullSize * 100);
 
         if (withinPanelLimits(first, firstSize, firstPercent) && withinPanelLimits(second, secondSize, secondPercent)) {
             setNewSizes(first, second, firstPercent, secondPercent, mainPanel);

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/BaseSplitter.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/BaseSplitter.java
@@ -36,7 +36,7 @@ abstract class BaseSplitter<T extends BaseSplitter<?>> extends BaseDominoElement
 
             if (LEFT_BUTTON == mouseEvent.buttons) {
                 double currentPosition = mousePosition(mouseEvent);
-                resize(first, second, currentPosition);
+                resize(first, second, currentPosition, mainPanel);
             }
         };
 
@@ -45,7 +45,7 @@ abstract class BaseSplitter<T extends BaseSplitter<?>> extends BaseDominoElement
             evt.stopPropagation();
             TouchEvent touchEvent = Js.uncheckedCast(evt);
             double currentPosition = touchPosition(touchEvent);
-            resize(first, second, currentPosition);
+            resize(first, second, currentPosition, mainPanel);
         };
 
         element.addEventListener(EventType.mousedown.getName(), evt -> {
@@ -72,7 +72,7 @@ abstract class BaseSplitter<T extends BaseSplitter<?>> extends BaseDominoElement
         document.body.addEventListener(EventType.touchend.getName(), evt -> document.body.removeEventListener(EventType.touchmove.getName(), touchResizeListener));
     }
 
-    private void resize(SplitPanel first, SplitPanel second, double currentPosition) {
+    private void resize(SplitPanel first, SplitPanel second, double currentPosition, HasSize mainPanel) {
         double diff = currentPosition - initialStartPosition;
 
         double firstSize = this.firstSize + diff;
@@ -81,7 +81,7 @@ abstract class BaseSplitter<T extends BaseSplitter<?>> extends BaseDominoElement
         double secondPercent = ((secondSize / fullSize) * 100);
 
         if (withinPanelLimits(first, firstSize, firstPercent) && withinPanelLimits(second, secondSize, secondPercent)) {
-            setNewSizes(first, second, firstPercent, secondPercent);
+            setNewSizes(first, second, firstPercent, secondPercent, mainPanel);
             first.onResize(firstSize, firstPercent);
             second.onResize(secondSize, secondPercent);
         }
@@ -99,7 +99,7 @@ abstract class BaseSplitter<T extends BaseSplitter<?>> extends BaseDominoElement
 
     protected abstract double getPanelSize(SplitPanel panel);
 
-    protected abstract void setNewSizes(SplitPanel first, SplitPanel second, double firstPercent, double secondPercent);
+    protected abstract void setNewSizes(SplitPanel first, SplitPanel second, double firstPercent, double secondPercent, HasSize mainPanel);
 
     protected abstract double mousePosition(MouseEvent event);
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/HSplitter.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/HSplitter.java
@@ -2,6 +2,8 @@ package org.dominokit.domino.ui.splitpanel;
 
 import elemental2.dom.MouseEvent;
 import elemental2.dom.TouchEvent;
+import org.dominokit.domino.ui.style.Calc;
+import org.dominokit.domino.ui.style.Unit;
 
 class HSplitter extends BaseSplitter<HSplitter> {
 
@@ -20,9 +22,9 @@ class HSplitter extends BaseSplitter<HSplitter> {
     }
 
     @Override
-    protected void setNewSizes(SplitPanel first, SplitPanel second, double firstPercent, double secondPercent) {
-        first.style().setWidth(firstPercent + "%");
-        second.style().setWidth(secondPercent + "%");
+    protected void setNewSizes(SplitPanel first, SplitPanel second, double firstPercent, double secondPercent, HasSize mainPanel) {
+        first.style().setWidth(Calc.sub(Unit.percent.of(firstPercent), Unit.px.of(mainPanel.getSplitterSize() / 2 * (mainPanel.numberOfPanels() - 1))));
+        second.style().setWidth(Calc.sub(Unit.percent.of(secondPercent), Unit.px.of(mainPanel.getSplitterSize() / 2 * (mainPanel.numberOfPanels() - 1))));
     }
 
     @Override

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/HSplitter.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/HSplitter.java
@@ -23,8 +23,8 @@ class HSplitter extends BaseSplitter<HSplitter> {
 
     @Override
     protected void setNewSizes(SplitPanel first, SplitPanel second, double firstPercent, double secondPercent, HasSize mainPanel) {
-        first.style().setWidth(Calc.sub(Unit.percent.of(firstPercent), Unit.px.of(mainPanel.getSplitterSize() / 2 * (mainPanel.numberOfPanels() - 1))));
-        second.style().setWidth(Calc.sub(Unit.percent.of(secondPercent), Unit.px.of(mainPanel.getSplitterSize() / 2 * (mainPanel.numberOfPanels() - 1))));
+        first.style().setWidth(Calc.sub(Unit.percent.of(firstPercent), Unit.px.of(first.isFirst() ?  mainPanel.getSplitterSize() / 2 : mainPanel.getSplitterSize())));
+        second.style().setWidth(Calc.sub(Unit.percent.of(secondPercent), Unit.px.of(second.isLast() ? mainPanel.getSplitterSize() / 2 : mainPanel.getSplitterSize())));
     }
 
     @Override
@@ -43,6 +43,6 @@ class HSplitter extends BaseSplitter<HSplitter> {
     }
 
     public void setSize(int size) {
-        setWidth(size + "px");
+        setWidth(Unit.px.of(size));
     }
 }

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/HasSize.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/HasSize.java
@@ -2,4 +2,6 @@ package org.dominokit.domino.ui.splitpanel;
 
 public interface HasSize {
     double getSize();
+    int numberOfPanels();
+    int getSplitterSize();
 }

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/HasSize.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/HasSize.java
@@ -2,6 +2,5 @@ package org.dominokit.domino.ui.splitpanel;
 
 public interface HasSize {
     double getSize();
-    int numberOfPanels();
     int getSplitterSize();
 }

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/SplitPanel.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/SplitPanel.java
@@ -16,6 +16,9 @@ public class SplitPanel extends BaseDominoElement<HTMLDivElement, SplitPanel> {
     private int minSize = 0;
     private int maxSize = -1;
 
+    private boolean isFirst = false;
+    private boolean isLast = false;
+
     private double minPercent = 0;
     private double maxPercent = 100;
     private final List<ResizeListener> resizeListeners = new ArrayList<>();
@@ -99,6 +102,21 @@ public class SplitPanel extends BaseDominoElement<HTMLDivElement, SplitPanel> {
         return this;
     }
 
+    public boolean isFirst() {
+        return isFirst;
+    }
+    public SplitPanel setFirst(boolean first) {
+        isFirst = first;
+        return this;
+    }
+
+    public boolean isLast() {
+        return isLast;
+    }
+    public SplitPanel setLast(boolean last) {
+        isLast = last;
+        return this;
+    }
 
     void onResize(double pixels, double percent) {
         resizeListeners.forEach(resizeListener -> resizeListener.onResize(SplitPanel.this, pixels, percent));

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/VSplitter.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/VSplitter.java
@@ -3,6 +3,7 @@ package org.dominokit.domino.ui.splitpanel;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.MouseEvent;
 import elemental2.dom.TouchEvent;
+import org.dominokit.domino.ui.style.Unit;
 
 class VSplitter extends BaseSplitter<VSplitter> {
 
@@ -15,9 +16,9 @@ class VSplitter extends BaseSplitter<VSplitter> {
         return new VSplitter(top, right, vSplitPanel);
     }
 
-    protected void setNewSizes(SplitPanel top, SplitPanel bottom, double topPercent, double bottomPercent) {
-        top.style().setHeight(topPercent + "%");
-        bottom.style().setHeight(bottomPercent + "%");
+    protected void setNewSizes(SplitPanel top, SplitPanel bottom, double topPercent, double bottomPercent, HasSize mainPanel) {
+        top.style().setHeight(Unit.percent.of(topPercent));
+        bottom.style().setHeight(Unit.percent.of(bottomPercent));
     }
 
     public double mousePosition(MouseEvent event) {

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/VSplitter.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/splitpanel/VSplitter.java
@@ -3,6 +3,7 @@ package org.dominokit.domino.ui.splitpanel;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.MouseEvent;
 import elemental2.dom.TouchEvent;
+import org.dominokit.domino.ui.style.Calc;
 import org.dominokit.domino.ui.style.Unit;
 
 class VSplitter extends BaseSplitter<VSplitter> {
@@ -17,8 +18,8 @@ class VSplitter extends BaseSplitter<VSplitter> {
     }
 
     protected void setNewSizes(SplitPanel top, SplitPanel bottom, double topPercent, double bottomPercent, HasSize mainPanel) {
-        top.style().setHeight(Unit.percent.of(topPercent));
-        bottom.style().setHeight(Unit.percent.of(bottomPercent));
+        top.style().setHeight(Calc.sub(Unit.percent.of(topPercent), Unit.px.of(top.isFirst() ? mainPanel.getSplitterSize() / 2 : mainPanel.getSplitterSize())));
+        bottom.style().setHeight(Calc.sub(Unit.percent.of(bottomPercent), Unit.px.of(bottom.isLast() ? mainPanel.getSplitterSize() / 2 : mainPanel.getSplitterSize())));
     }
 
     public double mousePosition(MouseEvent event) {
@@ -47,6 +48,6 @@ class VSplitter extends BaseSplitter<VSplitter> {
     }
 
     public void setSize(int size) {
-        setHeight(size + "px");
+        setHeight(Unit.px.of(size));
     }
 }


### PR DESCRIPTION
There is an issue with split panel sizes, e.g. when creating a 50%:50% split, the HSplitter is not centered in the middle of the main panel container on page init. 
Further, when resizing a horizontal split panel whose main panel is 100% percent wide and resizing the browser window afterwards, the computed width percentages may not fit anymore for the given splitterSize resulting in rendering issues for the content. 

The provided approach here simplifies the computation of sizes, as it always uses overall percentages and substracts the splitterSizes afterwards.