### PR TITLE
Added option to parseStrict to DateBox

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/datepicker/DateBox.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/datepicker/DateBox.java
@@ -35,6 +35,8 @@ public class DateBox extends ValueBox<DateBox, HTMLInputElement, Date> {
     private DatePicker datePicker;
     private String pattern;
 
+    private boolean parseStrict;
+
     private Popover popover;
     private ModalDialog modal;
     private EventListener modalListener;
@@ -176,7 +178,8 @@ public class DateBox extends ValueBox<DateBox, HTMLInputElement, Date> {
 
     private Date getFormattedValue(String value) throws IllegalArgumentException {
         DateTimeFormatInfo dateTimeFormatInfo = datePicker.getDateTimeFormatInfo();
-        return Formatter.getFormat(this.pattern, dateTimeFormatInfo).parse(value);
+        if (parseStrict) return Formatter.getFormat(this.pattern, dateTimeFormatInfo).parseStrict(value);
+        else return Formatter.getFormat(this.pattern, dateTimeFormatInfo).parse(value);
     }
 
     public static DateBox create() {
@@ -198,6 +201,12 @@ public class DateBox extends ValueBox<DateBox, HTMLInputElement, Date> {
     public static DateBox create(String label, Date date, DateTimeFormatInfo dateTimeFormatInfo) {
         return new DateBox(label, date, dateTimeFormatInfo);
     }
+
+    public DateBox setParseStrict(boolean parseStrict) {
+        this.parseStrict = parseStrict;
+        return this;
+    }
+
 
     public DateBox setPattern(Pattern pattern) {
         switch (pattern) {

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/datepicker/DateBox.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/datepicker/DateBox.java
@@ -35,8 +35,6 @@ public class DateBox extends ValueBox<DateBox, HTMLInputElement, Date> {
     private DatePicker datePicker;
     private String pattern;
 
-    private boolean parseStrict;
-
     private Popover popover;
     private ModalDialog modal;
     private EventListener modalListener;
@@ -52,6 +50,7 @@ public class DateBox extends ValueBox<DateBox, HTMLInputElement, Date> {
     private FlexItem calendarIconContainer;
     private MdiIcon calendarIcon;
     private boolean openOnClick = true;
+    private boolean parseStrict;
 
     public DateBox() {
         this(new Date());
@@ -178,8 +177,10 @@ public class DateBox extends ValueBox<DateBox, HTMLInputElement, Date> {
 
     private Date getFormattedValue(String value) throws IllegalArgumentException {
         DateTimeFormatInfo dateTimeFormatInfo = datePicker.getDateTimeFormatInfo();
-        if (parseStrict) return Formatter.getFormat(this.pattern, dateTimeFormatInfo).parseStrict(value);
-        else return Formatter.getFormat(this.pattern, dateTimeFormatInfo).parse(value);
+        if (parseStrict) {
+            return Formatter.getFormat(this.pattern, dateTimeFormatInfo).parseStrict(value);
+        }
+        return Formatter.getFormat(this.pattern, dateTimeFormatInfo).parse(value);
     }
 
     public static DateBox create() {
@@ -206,7 +207,6 @@ public class DateBox extends ValueBox<DateBox, HTMLInputElement, Date> {
         this.parseStrict = parseStrict;
         return this;
     }
-
 
     public DateBox setPattern(Pattern pattern) {
         switch (pattern) {


### PR DESCRIPTION
You can now call setParseStrict(true) to enable parseStrict to be used for the Formatter.

Default behaviour is normal parse, like beore