### PR TITLE
Ignore keyboard events without keycode

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/keyboard/KeyboardEvents.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/keyboard/KeyboardEvents.java
@@ -30,6 +30,10 @@ public class KeyboardEvents<T extends Node> {
     public KeyboardEvents(T element) {
         element.addEventListener(KEYDOWN, evt -> {
             KeyboardEvent keyboardEvent = Js.uncheckedCast(evt);
+            // ignore events without keycode (browser bug?)
+            // example: picking value by keyboard from Chrome auto-suggest
+            if (keyboardEvent.key == null)
+            	return;
             String key = keyboardEvent.key.toLowerCase();
             HandlerContext handlerContext = null;
             if (keyboardEvent.ctrlKey && ctrlHandlers.containsKey(key)) {


### PR DESCRIPTION
Probably result of a browser bug.

Closes #436.