### PR TITLE
Add (partial) generics specialization

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/Typography/Blockquote.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/Typography/Blockquote.java
@@ -90,7 +90,7 @@ public class Blockquote extends BaseDominoElement<HTMLElement, Blockquote> {
         return this;
     }
 
-    public Blockquote appendFooterChild(IsElement content) {
+    public <E extends HTMLElement> Blockquote appendFooterChild(IsElement<E> content) {
         return appendFooterChild(content.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/animations/Animation.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/animations/Animation.java
@@ -39,11 +39,11 @@ public class Animation {
         return new Animation(element);
     }
 
-    public static Animation create(BaseDominoElement element) {
+    public static <E extends HTMLElement, T extends IsElement<E>> Animation create(BaseDominoElement<E, T> element) {
         return new Animation(element.element());
     }
 
-    public static Animation create(IsElement element) {
+    public static <E extends HTMLElement> Animation create(IsElement<E> element) {
         return new Animation(element.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/button/DropdownButton.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/button/DropdownButton.java
@@ -144,11 +144,11 @@ public class DropdownButton extends BaseButton<DropdownButton> {
      * @deprecated use {@link #appendChild(DropdownAction)}
      */
     @Deprecated
-    public DropdownButton addAction(DropdownAction action) {
+    public DropdownButton addAction(DropdownAction<?> action) {
         return appendChild(action);
     }
 
-    public DropdownButton appendChild(DropdownAction action) {
+    public DropdownButton appendChild(DropdownAction<?> action) {
         dropDownMenu.addAction(action);
         return this;
     }

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/cards/Card.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/cards/Card.java
@@ -121,7 +121,7 @@ public class Card extends BaseDominoElement<HTMLDivElement, Card> implements Has
         return this;
     }
 
-    public Card appendDescriptionChild(IsElement element) {
+    public <E extends HTMLElement> Card appendDescriptionChild(IsElement<E> element) {
         return appendDescriptionChild(element.element());
     }
 
@@ -131,7 +131,7 @@ public class Card extends BaseDominoElement<HTMLDivElement, Card> implements Has
         return this;
     }
 
-    public Card appendChild(IsElement element) {
+    public <E extends HTMLElement> Card appendChild(IsElement<E> element) {
         getBody().appendChild(element.element());
         return this;
     }
@@ -321,7 +321,7 @@ public class Card extends BaseDominoElement<HTMLDivElement, Card> implements Has
         return this;
     }
 
-    public Card setHeaderLogo(IsElement<?> element) {
+    public <E extends HTMLElement> Card setHeaderLogo(IsElement<E> element) {
         setHeaderLogo(element.element());
         return this;
     }

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/chips/Chip.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/chips/Chip.java
@@ -131,7 +131,7 @@ public class Chip extends BaseDominoElement<HTMLDivElement, Chip> implements Has
         return this;
     }
 
-    public Chip setRemoveIcon(IsElement removeIcon) {
+    public <E extends HTMLElement> Chip setRemoveIcon(IsElement<E> removeIcon) {
         return setRemoveIcon(removeIcon.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/collapsible/AccordionPanel.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/collapsible/AccordionPanel.java
@@ -2,6 +2,7 @@ package org.dominokit.domino.ui.collapsible;
 
 import elemental2.dom.HTMLAnchorElement;
 import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
 import elemental2.dom.HTMLHeadingElement;
 import elemental2.dom.Node;
 import org.dominokit.domino.ui.icons.BaseIcon;
@@ -51,7 +52,7 @@ public class AccordionPanel extends BaseDominoElement<HTMLDivElement, AccordionP
         return new AccordionPanel(title, content);
     }
 
-    public static AccordionPanel create(String title, IsElement content) {
+    public static <E extends HTMLElement> AccordionPanel create(String title, IsElement<E> content) {
         return new AccordionPanel(title, content.element());
     }
 
@@ -80,7 +81,7 @@ public class AccordionPanel extends BaseDominoElement<HTMLDivElement, AccordionP
         return this;
     }
 
-    public AccordionPanel appendChild(IsElement content) {
+    public <E extends HTMLElement> AccordionPanel appendChild(IsElement<E> content) {
         return appendChild(content.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/collapsible/Collapsible.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/collapsible/Collapsible.java
@@ -32,7 +32,7 @@ public class Collapsible implements IsElement<HTMLElement>, IsCollapsible<Collap
         return new Collapsible(element);
     }
 
-    public static Collapsible create(IsElement isElement) {
+    public static <E extends HTMLElement> Collapsible create(IsElement<E> isElement) {
         return create(isElement.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/datatable/plugins/SelectionPlugin.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/datatable/plugins/SelectionPlugin.java
@@ -41,7 +41,7 @@ public class SelectionPlugin<T> implements DataTablePlugin<T> {
         this.singleSelectIndicator = singleSelectIndicator;
     }
 
-    public SelectionPlugin(ColorScheme colorScheme, IsElement singleSelectIndicator) {
+    public <E extends HTMLElement> SelectionPlugin(ColorScheme colorScheme, IsElement<E> singleSelectIndicator) {
         this(colorScheme, singleSelectIndicator.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/dialogs/MessageDialog.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/dialogs/MessageDialog.java
@@ -185,7 +185,7 @@ public class MessageDialog extends BaseModal<MessageDialog> {
         return this;
     }
 
-    public MessageDialog appendHeaderChild(IsElement content) {
+    public <E extends HTMLElement> MessageDialog appendHeaderChild(IsElement<E> content) {
         return appendHeaderChild(content.element());
     }
 }

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/dropdown/DropDownMenu.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/dropdown/DropDownMenu.java
@@ -25,7 +25,7 @@ import static org.jboss.elemento.Elements.*;
 
 public class DropDownMenu extends BaseDominoElement<HTMLDivElement, DropDownMenu> implements HasBackground<DropDownMenu> {
 
-    private MenuNavigation<DropdownAction> menuNavigation;
+    private MenuNavigation<DropdownAction<?>> menuNavigation;
     private DominoElement<HTMLDivElement> element = DominoElement.of(div().css(DropDownStyles.DROPDOWN));
     private DominoElement<HTMLUListElement> menuElement = DominoElement.of(ul().css(DropDownStyles.DROPDOWN_MENU));
     private HTMLElement targetElement;
@@ -37,14 +37,14 @@ public class DropDownMenu extends BaseDominoElement<HTMLDivElement, DropDownMenu
     private DominoElement<HTMLElement> noSearchResultsElement;
     private String noMatchSearchResultText = "No results matched";
 
-    private List<DropdownAction> actions = new ArrayList<>();
+    private List<DropdownAction<?>> actions = new ArrayList<>();
     private static boolean touchMoved;
     private List<CloseHandler> closeHandlers = new ArrayList<>();
     private List<OpenHandler> openHandlers = new ArrayList<>();
     private boolean closeOnEscape;
     private boolean searchable;
     private boolean caseSensitiveSearch = false;
-    private List<DropdownActionsGroup> groups = new ArrayList<>();
+    private List<DropdownActionsGroup<?>> groups = new ArrayList<>();
     private Color background;
     private HTMLElement appendTarget = document.body;
     private AppendStrategy appendStrategy = AppendStrategy.LAST;
@@ -121,7 +121,7 @@ public class DropDownMenu extends BaseDominoElement<HTMLDivElement, DropDownMenu
     }
 
     private void selectFirstSearchResult() {
-        List<DropdownAction> filteredAction = getFilteredAction();
+        List<DropdownAction<?>> filteredAction = getFilteredAction();
         if (!filteredAction.isEmpty()) {
             selectAt(actions.indexOf(filteredAction.get(0)));
             filteredAction.get(0)
@@ -172,7 +172,7 @@ public class DropDownMenu extends BaseDominoElement<HTMLDivElement, DropDownMenu
         groups.forEach(DropdownActionsGroup::changeVisibility);
     }
 
-    public List<DropdownAction> getFilteredAction() {
+    public List<DropdownAction<?>> getFilteredAction() {
         return actions
                 .stream()
                 .filter(dropdownAction -> !dropdownAction.isFilteredOut())
@@ -209,11 +209,11 @@ public class DropDownMenu extends BaseDominoElement<HTMLDivElement, DropDownMenu
         return new DropDownMenu(targetElement);
     }
 
-    public static DropDownMenu create(IsElement targetElement) {
+    public static <E extends HTMLElement> DropDownMenu create(IsElement<E> targetElement) {
         return new DropDownMenu(targetElement.element());
     }
 
-    public DropDownMenu insertFirst(DropdownAction action) {
+    public DropDownMenu insertFirst(DropdownAction<?> action) {
         action.addSelectionHandler(value -> {
             if (action.isAutoClose()) {
                 close();
@@ -224,7 +224,7 @@ public class DropDownMenu extends BaseDominoElement<HTMLDivElement, DropDownMenu
         return this;
     }
 
-    public DropDownMenu appendChild(DropdownAction action) {
+    public DropDownMenu appendChild(DropdownAction<?> action) {
         action.addSelectionHandler(value -> {
             if (action.isAutoClose()) {
                 close();
@@ -236,7 +236,7 @@ public class DropDownMenu extends BaseDominoElement<HTMLDivElement, DropDownMenu
         return this;
     }
 
-    public DropDownMenu addAction(DropdownAction action) {
+    public DropDownMenu addAction(DropdownAction<?> action) {
         return appendChild(action);
     }
 
@@ -346,7 +346,7 @@ public class DropDownMenu extends BaseDominoElement<HTMLDivElement, DropDownMenu
         return this;
     }
 
-    public List<DropdownAction> getActions() {
+    public List<DropdownAction<?>> getActions() {
         return actions;
     }
 
@@ -365,7 +365,7 @@ public class DropDownMenu extends BaseDominoElement<HTMLDivElement, DropDownMenu
         return this;
     }
 
-    public DropDownMenu addGroup(DropdownActionsGroup group) {
+    public DropDownMenu addGroup(DropdownActionsGroup<?> group) {
         groups.add(group);
         menuElement.appendChild(group.element());
         group.bindTo(this);

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/dropdown/DropdownActionsGroup.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/dropdown/DropdownActionsGroup.java
@@ -40,7 +40,7 @@ public class DropdownActionsGroup<T> extends BaseDominoElement<HTMLLIElement, Dr
         return create((Node) titleElement);
     }
 
-    public static <T> DropdownActionsGroup<T> create(IsElement titleElement) {
+    public static <T, E extends HTMLElement> DropdownActionsGroup<T> create(IsElement<E> titleElement) {
         return create(titleElement.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/dropdown/MenuNavigation.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/dropdown/MenuNavigation.java
@@ -12,7 +12,7 @@ import java.util.List;
 import static java.util.Objects.isNull;
 import static org.dominokit.domino.ui.utils.ElementUtil.*;
 
-public class MenuNavigation<V extends IsElement> implements EventListener {
+public class MenuNavigation<V extends IsElement<?>> implements EventListener {
 
     private final List<V> items;
     private FocusHandler<V> focusHandler;
@@ -24,7 +24,7 @@ public class MenuNavigation<V extends IsElement> implements EventListener {
         this.items = items;
     }
 
-    public static <V extends IsElement> MenuNavigation<V> create(List<V> items) {
+    public static <V extends IsElement<E>, E extends HTMLElement> MenuNavigation<V> create(List<V> items) {
         return new MenuNavigation<>(items);
     }
 
@@ -141,12 +141,12 @@ public class MenuNavigation<V extends IsElement> implements EventListener {
     }
 
     @FunctionalInterface
-    public interface FocusHandler<V extends IsElement> {
+    public interface FocusHandler<V> {
         void doFocus(V item);
     }
 
     @FunctionalInterface
-    public interface SelectHandler<V extends IsElement> {
+    public interface SelectHandler<V> {
         void doSelect(V item);
 
     }
@@ -157,7 +157,7 @@ public class MenuNavigation<V extends IsElement> implements EventListener {
     }
 
     @FunctionalInterface
-    public interface FocusCondition<V extends IsElement> {
+    public interface FocusCondition<V> {
         boolean shouldFocus(V item);
     }
 }

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/forms/BasicFormElement.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/forms/BasicFormElement.java
@@ -76,7 +76,7 @@ public abstract class BasicFormElement<T extends BasicFormElement<T, V>, V> exte
         return (T) this;
     }
 
-    public T setLabel(IsElement<?> element) {
+    public <E extends HTMLElement> T setLabel(IsElement<E> element) {
         return setLabel(element.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/forms/Radio.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/forms/Radio.java
@@ -215,7 +215,7 @@ public class Radio<T> extends BaseDominoElement<HTMLDivElement, Radio<T>> implem
         return this;
     }
 
-    public Radio<T> setLabel(IsElement<?> element) {
+    public <E extends HTMLElement> Radio<T> setLabel(IsElement<E> element) {
         return setLabel(element.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/forms/RadioGroup.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/forms/RadioGroup.java
@@ -60,7 +60,7 @@ public class RadioGroup<T> extends AbstractValueBox<RadioGroup<T>, HTMLElement, 
         return this;
     }
 
-    public RadioGroup<T> appendChild(Radio<? extends T> radio, IsElement content) {
+    public <E extends HTMLElement> RadioGroup<T> appendChild(Radio<? extends T> radio, IsElement<E> content) {
         return appendChild(radio, content.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/forms/SelectOption.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/forms/SelectOption.java
@@ -73,7 +73,7 @@ public class SelectOption<T> extends BaseDominoElement<HTMLDivElement, SelectOpt
         return this;
     }
 
-    public SelectOption<T> appendChild(IsElement node) {
+    public <E extends HTMLElement> SelectOption<T> appendChild(IsElement<E> node) {
         element.appendChild(node.element());
         return this;
     }

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/forms/SelectOptionGroup.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/forms/SelectOptionGroup.java
@@ -44,7 +44,7 @@ public class SelectOptionGroup<T> extends BaseDominoElement<HTMLLIElement, Selec
         return create((Node) titleElement);
     }
 
-    public static <T> SelectOptionGroup<T> create(IsElement titleElement) {
+    public static <T, E extends HTMLElement> SelectOptionGroup<T> create(IsElement<E> titleElement) {
         return create(titleElement.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/forms/SuggestBox.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/forms/SuggestBox.java
@@ -112,7 +112,7 @@ public class SuggestBox<T> extends AbstractValueBox<SuggestBox<T>, HTMLInputElem
                         evt.stopPropagation();
                         evt.preventDefault();
                         if(isAutoSelect()) {
-                            List<DropdownAction> filteredActions = suggestionsMenu.getFilteredAction();
+                            List<DropdownAction<?>> filteredActions = suggestionsMenu.getFilteredAction();
                             suggestionsMenu.selectAt(suggestionsMenu.getActions().indexOf(filteredActions.get(0)));
                             filteredActions.get(0).select();
                             suggestionsMenu.close();

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/forms/ValueBox.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/forms/ValueBox.java
@@ -408,7 +408,7 @@ public abstract class ValueBox<T extends ValueBox<T, E, V>, E extends HTMLElemen
      * @deprecated use {@link #addLeftAddOn(FlexItem)}
      */
     @Deprecated
-    public T setLeftAddon(IsElement leftAddon) {
+    public <E extends HTMLElement> T setLeftAddon(IsElement<E> leftAddon) {
         return addLeftAddOn(FlexItem.create().appendChild(leftAddon.element()));
     }
 
@@ -430,7 +430,7 @@ public abstract class ValueBox<T extends ValueBox<T, E, V>, E extends HTMLElemen
         return (T) this;
     }
 
-    public T addLeftAddOn(IsElement<?> addon) {
+    public <E extends HTMLElement> T addLeftAddOn(IsElement<E> addon) {
         return addLeftAddOn(FlexItem.create().appendChild(addon));
     }
 
@@ -444,7 +444,7 @@ public abstract class ValueBox<T extends ValueBox<T, E, V>, E extends HTMLElemen
      * @deprecated use {@link #addRightAddOn(FlexItem)}
      */
     @Deprecated
-    public T setRightAddon(IsElement rightAddon) {
+    public <E extends HTMLElement> T setRightAddon(IsElement<E> rightAddon) {
         return addRightAddOn(FlexItem.create().appendChild(rightAddon.element()));
     }
 
@@ -466,7 +466,7 @@ public abstract class ValueBox<T extends ValueBox<T, E, V>, E extends HTMLElemen
         return (T) this;
     }
 
-    public T addRightAddOn(IsElement<?> addon) {
+    public <E extends HTMLElement> T addRightAddOn(IsElement<E> addon) {
         addRightAddOn(FlexItem.create().appendChild(addon));
         return (T) this;
     }
@@ -480,7 +480,7 @@ public abstract class ValueBox<T extends ValueBox<T, E, V>, E extends HTMLElemen
         return removeRightAddOn(addon.element());
     }
 
-    public T removeRightAddOn(IsElement<?> addon) {
+    public <E extends HTMLElement> T removeRightAddOn(IsElement<E> addon) {
         return removeRightAddOn(addon.element());
     }
 
@@ -499,7 +499,7 @@ public abstract class ValueBox<T extends ValueBox<T, E, V>, E extends HTMLElemen
         return removeLeftAddOn(addon.element());
     }
 
-    public T removeLeftAddOn(IsElement<?> addon) {
+    public <E extends HTMLElement> T removeLeftAddOn(IsElement<E> addon) {
         return removeLeftAddOn(addon.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/grid/Row.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/grid/Row.java
@@ -97,7 +97,7 @@ public class Row<T extends Row<T>> extends BaseDominoElement<HTMLDivElement, T> 
         return (T) this;
     }
 
-    public T appendChild(IsElement element) {
+    public <E extends HTMLElement> T appendChild(IsElement<E> element) {
         row.appendChild(element.element());
         return (T) this;
     }

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/header/BlockHeader.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/header/BlockHeader.java
@@ -55,7 +55,7 @@ public class BlockHeader extends BaseDominoElement<HTMLDivElement, BlockHeader> 
         return this;
     }
 
-    public BlockHeader appendChild(IsElement content) {
+    public <E extends HTMLElement> BlockHeader appendChild(IsElement<E> content) {
         return appendChild(content.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/keyboard/KeyboardEvents.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/keyboard/KeyboardEvents.java
@@ -1,6 +1,7 @@
 package org.dominokit.domino.ui.keyboard;
 
 import elemental2.dom.EventListener;
+import elemental2.dom.HTMLElement;
 import elemental2.dom.KeyboardEvent;
 import elemental2.dom.Node;
 import jsinterop.base.Js;
@@ -58,7 +59,7 @@ public class KeyboardEvents<T extends Node> {
         return new KeyboardEvents<>(element);
     }
 
-    public static KeyboardEvents listenOn(IsElement element) {
+    public static <E extends HTMLElement> KeyboardEvents listenOn(IsElement<E> element) {
         return new KeyboardEvents<>(element.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/layout/Layout.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/layout/Layout.java
@@ -339,7 +339,7 @@ public class Layout extends BaseDominoElement<HTMLDivElement, Layout> {
         return addActionItem(icon.element());
     }
 
-    public HTMLElement addActionItem(IsElement element) {
+    public <E extends HTMLElement> HTMLElement addActionItem(IsElement<E> element) {
         return addActionItem(element.element());
     }
 
@@ -449,7 +449,7 @@ public class Layout extends BaseDominoElement<HTMLDivElement, Layout> {
         return this;
     }
 
-    public Layout setContent(IsElement element) {
+    public <E extends HTMLElement> Layout setContent(IsElement<E> element) {
         setContent(element.element());
         return this;
     }

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/layout/LayoutActionItem.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/layout/LayoutActionItem.java
@@ -22,7 +22,7 @@ public class LayoutActionItem extends BaseDominoElement<HTMLLIElement, LayoutAct
         this(baseIcon.element());
     }
 
-    public LayoutActionItem(IsElement<?> isElement) {
+    public <E extends HTMLElement> LayoutActionItem(IsElement<E> isElement) {
         this(isElement.element());
     }
 
@@ -30,7 +30,7 @@ public class LayoutActionItem extends BaseDominoElement<HTMLLIElement, LayoutAct
         return new LayoutActionItem(baseIcon);
     }
 
-    public static LayoutActionItem create(IsElement<?> isElement){
+    public static <E extends HTMLElement> LayoutActionItem create(IsElement<E> isElement){
         return new LayoutActionItem(isElement);
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/loaders/Loader.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/loaders/Loader.java
@@ -22,7 +22,7 @@ public class Loader {
         return new Loader(target, effect);
     }
 
-    public static Loader create(IsElement target, LoaderEffect effect) {
+    public static <E extends HTMLElement> Loader create(IsElement<E> target, LoaderEffect effect) {
         return new Loader(target.element(), effect);
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/media/MediaObject.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/media/MediaObject.java
@@ -1,6 +1,7 @@
 package org.dominokit.domino.ui.media;
 
 import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
 import elemental2.dom.HTMLHeadingElement;
 import elemental2.dom.Node;
 import org.dominokit.domino.ui.style.Styles;
@@ -59,7 +60,7 @@ public class MediaObject extends BaseDominoElement<HTMLDivElement, MediaObject> 
         return this;
     }
 
-    public MediaObject setLeftMedia(IsElement element) {
+    public <E extends HTMLElement> MediaObject setLeftMedia(IsElement<E> element) {
         return setLeftMedia(element.element());
     }
 
@@ -74,7 +75,7 @@ public class MediaObject extends BaseDominoElement<HTMLDivElement, MediaObject> 
         return this;
     }
 
-    public MediaObject setRightMedia(IsElement element) {
+    public <E extends HTMLElement> MediaObject setRightMedia(IsElement<E> element) {
         return setRightMedia(element.element());
     }
 
@@ -83,7 +84,7 @@ public class MediaObject extends BaseDominoElement<HTMLDivElement, MediaObject> 
         return this;
     }
 
-    public MediaObject appendChild(IsElement content) {
+    public <E extends HTMLElement> MediaObject appendChild(IsElement<E> content) {
         return appendChild(content.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/modals/BaseModal.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/modals/BaseModal.java
@@ -171,7 +171,7 @@ public abstract class BaseModal<T extends IsElement<HTMLDivElement>> extends Bas
     }
 
     @Override
-    public T appendChild(IsElement content) {
+    public <E extends HTMLElement> T appendChild(IsElement<E> content) {
         return appendChild(content.element());
     }
 
@@ -182,7 +182,7 @@ public abstract class BaseModal<T extends IsElement<HTMLDivElement>> extends Bas
     }
 
     @Override
-    public T appendFooterChild(IsElement content) {
+    public <E extends HTMLElement> T appendFooterChild(IsElement<E> content) {
         return appendFooterChild(content.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/modals/IsModalDialog.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/modals/IsModalDialog.java
@@ -1,6 +1,7 @@
 package org.dominokit.domino.ui.modals;
 
 import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
 import elemental2.dom.HTMLHeadingElement;
 import elemental2.dom.Node;
 import org.dominokit.domino.ui.style.Color;
@@ -11,11 +12,11 @@ public interface IsModalDialog<T> {
 
     T appendChild(Node content);
 
-    T appendChild(IsElement content);
+    <E extends HTMLElement> T appendChild(IsElement<E> content);
 
     T appendFooterChild(Node content);
 
-    T appendFooterChild(IsElement content);
+    <E extends HTMLElement> T appendFooterChild(IsElement<E> content);
 
     T large();
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/popover/Popover.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/popover/Popover.java
@@ -137,7 +137,7 @@ public class Popover extends BaseDominoElement<HTMLDivElement, Popover> implemen
         return popover;
     }
 
-    public static Popover createPicker(IsElement target, IsElement content) {
+    public static <E1 extends HTMLElement, E2 extends HTMLElement> Popover createPicker(IsElement<E1> target, IsElement<E2> content) {
         Popover popover = new Popover(target.element(), "", content.element());
         popover.getHeadingElement().style().setDisplay("none");
         popover.getContentElement().style().setProperty("padding", "0px");
@@ -149,15 +149,15 @@ public class Popover extends BaseDominoElement<HTMLDivElement, Popover> implemen
         return new Popover(target, title, content);
     }
 
-    public static Popover create(HTMLElement target, String title, IsElement content) {
+    public static <E extends HTMLElement> Popover create(HTMLElement target, String title, IsElement<E> content) {
         return new Popover(target, title, content.element());
     }
 
-    public static Popover create(IsElement target, String title, Node content) {
+    public static <E extends HTMLElement> Popover create(IsElement<E> target, String title, Node content) {
         return new Popover(target.element(), title, content);
     }
 
-    public static Popover create(IsElement target, String title, IsElement content) {
+    public static <E1 extends HTMLElement, E2 extends HTMLElement> Popover create(IsElement<E1> target, String title, IsElement<E2> content) {
         return new Popover(target.element(), title, content.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/popover/Tooltip.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/popover/Tooltip.java
@@ -80,11 +80,11 @@ public class Tooltip extends BaseDominoElement<HTMLDivElement, Tooltip> {
         return new Tooltip(target, content);
     }
 
-    public static Tooltip create(IsElement element, String text) {
+    public static <E extends HTMLElement> Tooltip create(IsElement<E> element, String text) {
         return new Tooltip(element.element(), text);
     }
 
-    public static Tooltip create(IsElement element, Node content) {
+    public static <E extends HTMLElement> Tooltip create(IsElement<E> element, Node content) {
         return new Tooltip(element.element(), content);
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/sliders/Slider.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/sliders/Slider.java
@@ -267,22 +267,22 @@ public class Slider extends BaseDominoElement<HTMLParagraphElement, Slider> impl
         return this;
     }
 
-    public Slider setLeftAddon(IsElement leftAddon) {
+    public <E extends HTMLElement> Slider setLeftAddon(IsElement<E> leftAddon) {
         return setLeftAddon(leftAddon.element());
     }
 
-    public Slider setLeftAddon(Element leftAddon) {
+    public Slider setLeftAddon(HTMLElement leftAddon) {
         leftAddonContainer.show();
         setAddon(leftAddonContainer.element(), this.leftAddon, leftAddon);
         this.leftAddon = leftAddon;
         return this;
     }
 
-    public Slider setRightAddon(IsElement rightAddon) {
+    public <E extends HTMLElement> Slider setRightAddon(IsElement<E> rightAddon) {
         return setRightAddon(rightAddon.element());
     }
 
-    public Slider setRightAddon(Element rightAddon) {
+    public Slider setRightAddon(HTMLElement rightAddon) {
         rightAddonContainer.show();
         setAddon(rightAddonContainer.element(), this.rightAddon, rightAddon);
         this.rightAddon = rightAddon;

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/spin/SpinItem.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/spin/SpinItem.java
@@ -1,6 +1,7 @@
 package org.dominokit.domino.ui.spin;
 
 import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
 import elemental2.dom.Node;
 import org.dominokit.domino.ui.utils.BaseDominoElement;
 import org.dominokit.domino.ui.utils.DominoElement;
@@ -23,7 +24,7 @@ public class SpinItem<T> extends BaseDominoElement<HTMLDivElement, SpinItem<T>> 
         setContent(content);
     }
 
-    public SpinItem(T value, IsElement content) {
+    public <E extends HTMLElement> SpinItem(T value, IsElement<E> content) {
         this(value);
         setContent(content);
     }
@@ -36,7 +37,7 @@ public class SpinItem<T> extends BaseDominoElement<HTMLDivElement, SpinItem<T>> 
         return new SpinItem<>(value, content);
     }
 
-    public static <T> SpinItem<T> create(T value, IsElement content) {
+    public static <T, E extends HTMLElement> SpinItem<T> create(T value, IsElement<E> content) {
         return new SpinItem<>(value, content);
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/steppers/Step.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/steppers/Step.java
@@ -1,6 +1,7 @@
 package org.dominokit.domino.ui.steppers;
 
 import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
 import elemental2.dom.HTMLLIElement;
 import elemental2.dom.Node;
 import org.dominokit.domino.ui.animations.Animation;
@@ -75,7 +76,7 @@ public class Step extends BaseDominoElement<HTMLLIElement, Step> {
         return this;
     }
 
-    public Step appendChild(IsElement content) {
+    public <E extends HTMLElement> Step appendChild(IsElement<E> content) {
         return appendChild(content.element());
     }
 
@@ -84,7 +85,7 @@ public class Step extends BaseDominoElement<HTMLLIElement, Step> {
         return this;
     }
 
-    public Step appendFooterChild(IsElement content) {
+    public <E extends HTMLElement> Step appendFooterChild(IsElement<E> content) {
         return appendFooterChild(content.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/tabs/Tab.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/tabs/Tab.java
@@ -2,6 +2,7 @@ package org.dominokit.domino.ui.tabs;
 
 import elemental2.dom.HTMLAnchorElement;
 import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
 import elemental2.dom.HTMLLIElement;
 import elemental2.dom.Node;
 import org.dominokit.domino.ui.grid.flex.FlexItem;
@@ -129,12 +130,12 @@ public class Tab extends BaseDominoElement<HTMLLIElement, Tab> implements HasCli
         return this;
     }
 
-    public Tab appendChild(IsElement content) {
+    public <E extends HTMLElement> Tab appendChild(IsElement<E> content) {
         return appendChild(content.element());
     }
 
     @Override
-    public Tab setContent(IsElement element) {
+    public <E extends HTMLElement> Tab setContent(IsElement<E> element) {
         return setContent(element.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/tabs/TabsPanel.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/tabs/TabsPanel.java
@@ -184,7 +184,7 @@ public class TabsPanel extends BaseDominoElement<HTMLDivElement, TabsPanel> impl
         return this;
     }
 
-    public TabsPanel setContentContainer(IsElement contentContainer) {
+    public <E extends HTMLElement> TabsPanel setContentContainer(IsElement<E> contentContainer) {
         return setContentContainer(contentContainer.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/tabs/VerticalTab.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/tabs/VerticalTab.java
@@ -123,7 +123,7 @@ public class VerticalTab extends WavesElement<HTMLDivElement, VerticalTab> imple
         return this;
     }
 
-    public VerticalTab appendChild(IsElement content) {
+    public <E extends HTMLElement> VerticalTab appendChild(IsElement<E> content) {
         return appendChild(content.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/tabs/VerticalTabsPanel.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/tabs/VerticalTabsPanel.java
@@ -219,7 +219,7 @@ public class VerticalTabsPanel extends BaseDominoElement<HTMLDivElement, Vertica
         return this;
     }
 
-    public VerticalTabsPanel setContentContainer(IsElement contentContainer) {
+    public <E extends HTMLElement> VerticalTabsPanel setContentContainer(IsElement<E> contentContainer) {
         return setContentContainer(contentContainer.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/thumbnails/Thumbnail.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/thumbnails/Thumbnail.java
@@ -1,6 +1,7 @@
 package org.dominokit.domino.ui.thumbnails;
 
 import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
 import elemental2.dom.Node;
 import org.dominokit.domino.ui.utils.BaseDominoElement;
 import org.dominokit.domino.ui.utils.DominoElement;
@@ -31,7 +32,7 @@ public class Thumbnail extends BaseDominoElement<HTMLDivElement, Thumbnail> {
         return this;
     }
 
-    public Thumbnail setContent(IsElement content) {
+    public <E extends HTMLElement> Thumbnail setContent(IsElement<E> content) {
         return setContent(content.element());
     }
 
@@ -50,7 +51,7 @@ public class Thumbnail extends BaseDominoElement<HTMLDivElement, Thumbnail> {
         return this;
     }
 
-    public Thumbnail appendCaptionChild(IsElement content) {
+    public <E extends HTMLElement> Thumbnail appendCaptionChild(IsElement<E> content) {
         return appendCaptionChild(content.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/tree/TreeItem.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/tree/TreeItem.java
@@ -583,7 +583,7 @@ public class TreeItem<T> extends WavesElement<HTMLLIElement, TreeItem<T>> implem
         return this;
     }
 
-    public TreeItem<T> setIndicatorContent(IsElement<?> element) {
+    public <E extends HTMLElement> TreeItem<T> setIndicatorContent(IsElement<E> element) {
         setIndicatorContent(element.element());
         return this;
     }

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/upload/FileUpload.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/upload/FileUpload.java
@@ -191,7 +191,7 @@ public class FileUpload extends BaseDominoElement<HTMLDivElement, FileUpload> im
         return this;
     }
 
-    public FileUpload appendChild(IsElement child) {
+    public <E extends HTMLElement> FileUpload appendChild(IsElement<E> child) {
         return appendChild(child.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/utils/BaseDominoElement.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/utils/BaseDominoElement.java
@@ -14,8 +14,6 @@ import org.jboss.elemento.EventType;
 import org.jboss.elemento.IsElement;
 import org.jboss.elemento.ObserverCallback;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 import static java.util.Objects.isNull;
@@ -38,7 +36,6 @@ public abstract class BaseDominoElement<E extends HTMLElement, T extends IsEleme
     private WavesSupport wavesSupport;
     private Optional<ElementObserver> attachObserver = Optional.empty();
     private Optional<ElementObserver> detachObserver = Optional.empty();
-    private boolean collapsed = false;
 
     @Editor.Ignore
     protected void init(T element) {
@@ -188,7 +185,7 @@ public abstract class BaseDominoElement<E extends HTMLElement, T extends IsEleme
 
     @Override
     @Editor.Ignore
-    public T appendChild(IsElement isElement) {
+    public <E2 extends HTMLElement> T appendChild(IsElement<E2> isElement) {
         element.element().appendChild(isElement.element());
         return element;
     }
@@ -206,13 +203,13 @@ public abstract class BaseDominoElement<E extends HTMLElement, T extends IsEleme
     }
 
     @Editor.Ignore
-    public T addEventListener(EventType type, EventListener listener) {
+    public T addEventListener(EventType<?, ?> type, EventListener listener) {
         element().addEventListener(type.getName(), listener);
         return element;
     }
 
     @Editor.Ignore
-    public T removeEventListener(EventType type, EventListener listener) {
+    public T removeEventListener(EventType<?, ?> type, EventListener listener) {
         element().removeEventListener(type.getName(), listener);
         return element;
     }
@@ -223,50 +220,52 @@ public abstract class BaseDominoElement<E extends HTMLElement, T extends IsEleme
         return element;
     }
 
-    @Editor.Ignore
+	@Editor.Ignore
+    @SuppressWarnings("unchecked")
     public T insertBefore(Node newNode, Node otherNode) {
         element().insertBefore(newNode, otherNode);
         return (T) this;
     }
 
     @Editor.Ignore
-    public T insertBefore(Node newNode, BaseDominoElement otherNode) {
+    public <OE extends HTMLElement, OT extends IsElement<OE>> T insertBefore(Node newNode, BaseDominoElement<OE, OT> otherNode) {
         element().insertBefore(newNode, otherNode.element());
         return element;
     }
 
     @Editor.Ignore
-    public T insertBefore(BaseDominoElement newNode, BaseDominoElement otherNode) {
+    public <NE extends HTMLElement, NT extends IsElement<NE>, OE extends HTMLElement, OT extends IsElement<OE>> T insertBefore(BaseDominoElement<NE, NT> newNode, BaseDominoElement<OE, OT> otherNode) {
         element().insertBefore(newNode.element(), otherNode.element());
         return element;
     }
 
     @Editor.Ignore
-    public T insertBefore(BaseDominoElement newNode, Node otherNode) {
+    public <NE extends HTMLElement, NT extends IsElement<NE>> T insertBefore(BaseDominoElement<NE, NT> newNode, Node otherNode) {
         element().insertBefore(newNode.element(), otherNode);
         return element;
     }
 
-    @Editor.Ignore
+	@Editor.Ignore
+    @SuppressWarnings("unchecked")
     public T insertAfter(Node newNode, Node otherNode) {
         element().insertBefore(newNode, otherNode.nextSibling);
         return (T) this;
     }
 
     @Editor.Ignore
-    public T insertAfter(Node newNode, BaseDominoElement otherNode) {
+    public <NE extends HTMLElement, NT extends IsElement<NE>> T insertAfter(Node newNode, BaseDominoElement<NE, NT> otherNode) {
         element().insertBefore(newNode, otherNode.element().nextSibling);
         return element;
     }
 
     @Editor.Ignore
-    public T insertAfter(BaseDominoElement newNode, BaseDominoElement otherNode) {
+    public <NE extends HTMLElement, NT extends IsElement<NE>, OE extends HTMLElement, OT extends IsElement<OE>> T insertAfter(BaseDominoElement<NE, NT> newNode, BaseDominoElement<OE, OT> otherNode) {
         element().insertBefore(newNode.element(), otherNode.element().nextSibling);
         return element;
     }
 
     @Editor.Ignore
-    public T insertAfter(BaseDominoElement newNode, Node otherNode) {
+    public <NE extends HTMLElement, NT extends IsElement<NE>> T insertAfter(BaseDominoElement<NE, NT> newNode, Node otherNode) {
         element().insertBefore(newNode.element(), otherNode.nextSibling);
         return element;
     }
@@ -278,12 +277,12 @@ public abstract class BaseDominoElement<E extends HTMLElement, T extends IsEleme
     }
 
     @Editor.Ignore
-    public T insertFirst(IsElement element) {
+    public <E2 extends HTMLElement> T insertFirst(IsElement<E2> element) {
         return insertFirst(element.element());
     }
 
     @Editor.Ignore
-    public T insertFirst(BaseDominoElement newNode) {
+    public <NE extends HTMLElement, NT extends IsElement<NE>> T insertFirst(BaseDominoElement<E, T> newNode) {
         element().insertBefore(newNode.element(), element().firstChild);
         return element;
     }
@@ -572,7 +571,7 @@ public abstract class BaseDominoElement<E extends HTMLElement, T extends IsEleme
 
 
     @Editor.Ignore
-    public T setContent(IsElement element) {
+    public <E2 extends HTMLElement> T setContent(IsElement<E2> element) {
         return setContent(element.element());
     }
 
@@ -644,6 +643,7 @@ public abstract class BaseDominoElement<E extends HTMLElement, T extends IsEleme
         return elevate(Elevation.of(level));
     }
 
+    @SuppressWarnings("unchecked")
     public T elevate(Elevation elevation) {
         if (nonNull(this.elevation)) {
             style.remove(this.elevation.getStyle());
@@ -691,30 +691,35 @@ public abstract class BaseDominoElement<E extends HTMLElement, T extends IsEleme
      */
     @Deprecated
     @Editor.Ignore
+    @SuppressWarnings("unchecked")
     public T removeShowHandler(Collapsible.ShowCompletedHandler handler) {
         collapsible.removeShowHandler(handler);
         return (T) this;
     }
 
     @Editor.Ignore
+    @SuppressWarnings("unchecked")
     public T addHideListener(Collapsible.HideCompletedHandler handler) {
         collapsible.addHideHandler(handler);
         return (T) this;
     }
 
     @Editor.Ignore
+    @SuppressWarnings("unchecked")
     public T removeHideListener(Collapsible.HideCompletedHandler handler) {
         collapsible.removeHideHandler(handler);
         return (T) this;
     }
 
     @Editor.Ignore
+    @SuppressWarnings("unchecked")
     public T addShowListener(Collapsible.ShowCompletedHandler handler) {
         collapsible.addShowHandler(handler);
         return (T) this;
     }
 
     @Editor.Ignore
+    @SuppressWarnings("unchecked")
     public T removeShowListener(Collapsible.ShowCompletedHandler handler) {
         collapsible.removeShowHandler(handler);
         return (T) this;

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/utils/ElementUtil.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/utils/ElementUtil.java
@@ -26,15 +26,15 @@ public class ElementUtil {
                 element.removeChild(element.firstChild);
     }
 
-    public static void clear(IsElement element) {
+    public static <E extends HTMLElement> void clear(IsElement<E> element) {
         clear(element.element());
     }
 
-    public static <T extends HTMLElement> HtmlContentBuilder<T> contentBuilder(T element) {
+    public static <E extends HTMLElement> HtmlContentBuilder<E> contentBuilder(E element) {
         return new HtmlContentBuilder<>(element);
     }
 
-    public static <T extends HTMLElement> HtmlContentBuilder<T> contentBuilder(IsElement<T> element) {
+    public static <E extends HTMLElement> HtmlContentBuilder<E> contentBuilder(IsElement<E> element) {
         return new HtmlContentBuilder<>(element.element());
     }
 
@@ -90,7 +90,7 @@ public class ElementUtil {
      * @param element
      * @param callback
      */
-    public static Optional<ElementObserver> onAttach(IsElement element, ObserverCallback callback) {
+    public static <E extends HTMLElement> Optional<ElementObserver> onAttach(IsElement<E> element, ObserverCallback callback) {
         if (element != null) {
             return Optional.of(BodyObserver.addAttachObserver(element.element(), callback));
         }
@@ -118,7 +118,7 @@ public class ElementUtil {
      * @param element
      * @param callback
      */
-    public static Optional<ElementObserver> onDetach(IsElement element, ObserverCallback callback) {
+    public static <E extends HTMLElement> Optional<ElementObserver> onDetach(IsElement<E> element, ObserverCallback callback) {
         if (element != null) {
             return Optional.of(BodyObserver.addDetachObserver(element.element(), callback));
         }
@@ -172,7 +172,7 @@ public class ElementUtil {
         DomGlobal.document.documentElement.scrollTop = 0;
     }
 
-    public static void scrollToElement(IsElement isElement) {
+    public static <E extends HTMLElement> void scrollToElement(IsElement<E> isElement) {
         scrollToElement(isElement.element());
     }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/utils/HasChildren.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/utils/HasChildren.java
@@ -1,9 +1,10 @@
 package org.dominokit.domino.ui.utils;
 
+import elemental2.dom.HTMLElement;
 import elemental2.dom.Node;
 import org.jboss.elemento.IsElement;
 
 public interface HasChildren<T> {
     T appendChild(Node node);
-    T appendChild(IsElement isElement);
+    <E extends HTMLElement> T appendChild(IsElement<E> isElement);
 }

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/utils/HtmlComponentBuilder.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/utils/HtmlComponentBuilder.java
@@ -26,7 +26,7 @@ public class HtmlComponentBuilder<E extends HTMLElement, T extends IsElement<E>>
     }
 
     @Override
-    public HtmlComponentBuilder<E, T> add(IsElement element) {
+    public HtmlComponentBuilder<E, T> add(IsElement<?> element) {
         super.add(element);
         return this;
     }
@@ -56,9 +56,9 @@ public class HtmlComponentBuilder<E extends HTMLElement, T extends IsElement<E>>
     }
 
     @Override
-    public HtmlComponentBuilder<E, T> addAll(IsElement... elements) {
-        super.addAll(elements);
-        return this;
+    public <F extends HTMLElement> HtmlComponentBuilder<E, T> addAll(IsElement<?>... elements) {
+      super.addAll(elements);
+      return this;
     }
 
     @Override
@@ -72,4 +72,5 @@ public class HtmlComponentBuilder<E extends HTMLElement, T extends IsElement<E>>
         super.css(classes);
         return this;
     }
+
 }


### PR DESCRIPTION
Domino UI lacks generics specialization in many places,
but this commit focuses on two classes:

* usage of elemento.IsElement
* BaseDominoElement implementation

Modification on some unrelated classes was needed too,
to make method signatures distinct enough for compiler.

Note that this could breake some projects which used @Override on
old (unspecialized) method variants.

This is NOT complete fix for lack of use of generics in Domino UI.
But it's a start.

Closes #439