### PR TITLE
BaseDominoElement.removeTooltip

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/utils/BaseDominoElement.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/utils/BaseDominoElement.java
@@ -442,6 +442,15 @@ public abstract class BaseDominoElement<E extends HTMLElement, T extends IsEleme
     }
 
     @Editor.Ignore
+    public T removeTooltip() {
+        if (nonNull(tooltip)) {
+        	tooltip.detach();
+        	tooltip = null;
+        }
+        return element;
+    }
+
+    @Editor.Ignore
     public HTMLElement getClickableElement() {
         return element();
     }


### PR DESCRIPTION
Although using `BaseDominoElement.getTooltip().detach()` we can remove existing tooltip, without null-ing `BaseDominoElement.tooltip` member it's impossible to set tooltip again later if required.

`BaseDominoElement.removeTooltip()` does (checked) cleanup if tooltip was set and prepares state to set it again.