### PR TITLE
move tree leveling from code to css

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/tree/Tree.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/tree/Tree.java
@@ -104,6 +104,7 @@ public class Tree<T> extends BaseDominoElement<HTMLDivElement, Tree<T>>
   private Icon searchIcon;
   private Icon collapseAllIcon;
   private Icon expandAllIcon;
+  private int levelPadding = 15;
 
   private T value;
 
@@ -175,6 +176,7 @@ public class Tree<T> extends BaseDominoElement<HTMLDivElement, Tree<T>>
     root.appendChild(treeItem.element());
     treeItem.setParent(this);
     treeItem.setLevel(1);
+    treeItem.setLevelPadding(levelPadding);
     treeItem.setToggleTarget(this.toggleTarget);
     this.subItems.add(treeItem);
     return this;
@@ -211,6 +213,19 @@ public class Tree<T> extends BaseDominoElement<HTMLDivElement, Tree<T>>
       subItems.forEach(item -> item.setToggleTarget(toggleTarget));
       this.toggleTarget = toggleTarget;
     }
+    return this;
+  }
+
+  /**
+   * Sets level padding for item
+   *
+   * @param levelPadding string with padding for item
+   * @return same instance
+   */
+  public Tree<T> setLevelPadding(int levelPadding) {
+    this.levelPadding = levelPadding;
+    subItems.forEach(item -> item.setLevelPadding(levelPadding));
+
     return this;
   }
 

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/tree/TreeItem.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/tree/TreeItem.java
@@ -61,7 +61,8 @@ public class TreeItem<T> extends WavesElement<HTMLLIElement, TreeItem<T>>
 
   private T value;
 
-  private int nextLevel = 1;
+  private int level = 1;
+  private int levelPadding = 15;
 
   private ToggleTarget toggleTarget = ToggleTarget.ANY;
   private final DominoElement<HTMLElement> indicatorContainer =
@@ -256,10 +257,11 @@ public class TreeItem<T> extends WavesElement<HTMLLIElement, TreeItem<T>>
     childrenContainer.appendChild(treeItem.element());
     Style.of(anchorElement).add("tree-toggle");
     treeItem.parent = this;
-    treeItem.setLevel(nextLevel);
+    treeItem.setLevel(level + 1);
     Style.of(treeItem).add("tree-leaf");
     Style.of(this.element()).remove("tree-leaf");
     treeItem.setToggleTarget(this.toggleTarget);
+    treeItem.setLevelPadding(levelPadding);
     this.style.add("tree-item-parent");
     return this;
   }
@@ -671,13 +673,38 @@ public class TreeItem<T> extends WavesElement<HTMLLIElement, TreeItem<T>>
    * Sets the level of this item
    *
    * @param level the new level
+   * @return same instance
    */
-  public void setLevel(int level) {
-    this.nextLevel = level + 1;
+  public TreeItem<T> setLevel(int level) {
+    this.level = level;
+    updateLevelPadding();
+
     if (isParent()) {
-      subItems.forEach(treeItem -> treeItem.setLevel(nextLevel));
+      subItems.forEach(treeItem -> treeItem.setLevel(level + 1));
     }
-    anchorElement.style().setPaddingLeft(px.of(nextLevel * 15));
+
+    return this;
+  }
+
+  /**
+   * Sets the level padding of this item
+   *
+   * @param levelPadding the new level padding
+   * @return same instance
+   */
+  public TreeItem<T> setLevelPadding(int levelPadding) {
+    this.levelPadding = levelPadding;
+    updateLevelPadding();
+
+    if (isParent()) {
+      subItems.forEach(treeItem -> treeItem.setLevelPadding(levelPadding));
+    }
+
+    return this;
+  }
+
+  private void updateLevelPadding() {
+    anchorElement.style().setPaddingLeft(px.of(level * levelPadding));
   }
 
   /** {@inheritDoc} */


### PR DESCRIPTION
in your code padding for tree levels hardcoded in sources. i move padding to css and remove unneeded code.
in result - padding can be easy configured

i tests with dominoui-demo and my own project, all works same except two small things:
* in your code first level has extra 15px padding (you leveling from 1st level instead 0). I think in my variant more correct behaviour, but if You want i can add extra padding for first level (via css).
* in my code  separarator lines also padded left to level. I dont know how change this for prev behaviour, but i also think: its looks more elegant ;-)

