### PR TITLE
GWT module per component (to allow individual use)

### DIFF
--- a/domino-ui/src/main/module.gwt.xml
+++ b/domino-ui/src/main/module.gwt.xml
@@ -17,14 +17,56 @@
 
 -->
 <module>
-    <inherits name="org.gwtproject.core.Core"/>
-    <inherits name="elemental2.svg.Svg"/>
-    <inherits name="elemental2.core.Core"/>
-    <inherits name="elemental2.dom.Dom"/>
-    <inherits name="org.jboss.elemento.Core"/>
-    <inherits name="org.gwtproject.i18n.CLDR"/>
-    <inherits name="org.gwtproject.i18n.DateTimeFormat"/>
-
-    <source path=""/>
-
+  <inherits name="org.dominokit.domino.ui.alerts.Alerts" />
+  <inherits name="org.dominokit.domino.ui.animations.Animations" />
+  <inherits name="org.dominokit.domino.ui.badges.Badges" />
+  <inherits name="org.dominokit.domino.ui.breadcrumbs.Breadcrumbs" />
+  <inherits name="org.dominokit.domino.ui.button.Button" />
+  <inherits name="org.dominokit.domino.ui.cards.Cards" />
+  <inherits name="org.dominokit.domino.ui.carousel.Carousel" />
+  <inherits name="org.dominokit.domino.ui.chips.Chips" />
+  <inherits name="org.dominokit.domino.ui.code.Code" />
+  <inherits name="org.dominokit.domino.ui.collapsible.Collapsible" />
+  <inherits name="org.dominokit.domino.ui.counter.Counter" />
+  <inherits name="org.dominokit.domino.ui.datatable.DataTable" />
+  <inherits name="org.dominokit.domino.ui.datepicker.DatePicker" />
+  <inherits name="org.dominokit.domino.ui.dialogs.Dialogs" />
+  <inherits name="org.dominokit.domino.ui.dropdown.DropDown" />
+  <inherits name="org.dominokit.domino.ui.forms.Forms" />
+  <inherits name="org.dominokit.domino.ui.grid.Grid" />
+  <inherits name="org.dominokit.domino.ui.header.Header" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.infoboxes.InfoBoxes" />
+  <inherits name="org.dominokit.domino.ui.keyboard.Keyboard" />
+  <inherits name="org.dominokit.domino.ui.labels.Labels" />
+  <inherits name="org.dominokit.domino.ui.layout.Layout" />
+  <inherits name="org.dominokit.domino.ui.lists.Lists" />
+  <inherits name="org.dominokit.domino.ui.loaders.Loaders" />
+  <inherits name="org.dominokit.domino.ui.media.Media" />
+  <inherits name="org.dominokit.domino.ui.mediaquery.MediaQuery" />
+  <inherits name="org.dominokit.domino.ui.modals.Modals" />
+  <inherits name="org.dominokit.domino.ui.notifications.Notifications" />
+  <inherits name="org.dominokit.domino.ui.pagination.Pagination" />
+  <inherits name="org.dominokit.domino.ui.pickers.Pickers" />
+  <inherits name="org.dominokit.domino.ui.popover.Popover" />
+  <inherits name="org.dominokit.domino.ui.preloaders.Preloaders" />
+  <inherits name="org.dominokit.domino.ui.progress.Progress" />
+  <inherits name="org.dominokit.domino.ui.scroll.Scroll" />
+  <inherits name="org.dominokit.domino.ui.search.Search" />
+  <inherits name="org.dominokit.domino.ui.sliders.Sliders" />
+  <inherits name="org.dominokit.domino.ui.spin.Spin" />
+  <inherits name="org.dominokit.domino.ui.splitpanel.SplitPanel" />
+  <inherits name="org.dominokit.domino.ui.stepper.Stepper" />
+  <inherits name="org.dominokit.domino.ui.steppers.Steppers" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.tabs.Tabs" />
+  <inherits name="org.dominokit.domino.ui.tag.Tag" />
+  <inherits name="org.dominokit.domino.ui.themes.Themes" />
+  <inherits name="org.dominokit.domino.ui.thumbnails.Thumbnails" />
+  <inherits name="org.dominokit.domino.ui.timepicker.TimePicker" />
+  <inherits name="org.dominokit.domino.ui.tree.Tree" />
+  <inherits name="org.dominokit.domino.ui.Typography.Typography" />
+  <inherits name="org.dominokit.domino.ui.upload.Upload" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <source path=""/>
 </module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/Typography/Typography.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/Typography/Typography.gwt.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/alerts/Alerts.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/alerts/Alerts.gwt.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.Typography.Typography" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/animations/Animations.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/animations/Animations.gwt.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.gwtproject.timer.Timer" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/badges/Badges.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/badges/Badges.gwt.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/breadcrumbs/Breadcrumbs.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/breadcrumbs/Breadcrumbs.gwt.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/button/Button.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/button/Button.gwt.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.dropdown.DropDown" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/cards/Cards.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/cards/Cards.gwt.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.collapsible.Collapsible" />
+  <inherits name="org.dominokit.domino.ui.grid.Grid" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.keyboard.Keyboard" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/carousel/Carousel.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/carousel/Carousel.gwt.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.gwtproject.timer.Timer" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/chips/Chips.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/chips/Chips.gwt.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.keyboard.Keyboard" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.themes.Themes" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/code/Code.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/code/Code.gwt.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/collapsible/Collapsible.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/collapsible/Collapsible.gwt.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/counter/Counter.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/counter/Counter.gwt.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.gwtproject.timer.Timer" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/datatable/DataTable.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/datatable/DataTable.gwt.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.button.Button" />
+  <inherits name="org.dominokit.domino.ui.datepicker.DatePicker" />
+  <inherits name="org.dominokit.domino.ui.dropdown.DropDown" />
+  <inherits name="org.dominokit.domino.ui.forms.Forms" />
+  <inherits name="org.dominokit.domino.ui.grid.Grid" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.layout.Layout" />
+  <inherits name="org.dominokit.domino.ui.pagination.Pagination" />
+  <inherits name="org.dominokit.domino.ui.popover.Popover" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.gwtproject.i18n.CLDR" />
+  <inherits name="org.gwtproject.timer.Timer" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/datepicker/DatePicker.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/datepicker/DatePicker.gwt.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.button.Button" />
+  <inherits name="org.dominokit.domino.ui.forms.Forms" />
+  <inherits name="org.dominokit.domino.ui.grid.Grid" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.modals.Modals" />
+  <inherits name="org.dominokit.domino.ui.pickers.Pickers" />
+  <inherits name="org.dominokit.domino.ui.popover.Popover" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.gwtproject.editor.Editor" />
+  <inherits name="org.gwtproject.i18n.DateTimeFormat" />
+  <inherits name="org.gwtproject.i18n.CLDR" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/dialogs/Dialogs.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/dialogs/Dialogs.gwt.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.Typography.Typography" />
+  <inherits name="org.dominokit.domino.ui.animations.Animations" />
+  <inherits name="org.dominokit.domino.ui.button.Button" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.modals.Modals" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/dropdown/DropDown.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/dropdown/DropDown.gwt.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.grid.Grid" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.keyboard.Keyboard" />
+  <inherits name="org.dominokit.domino.ui.modals.Modals" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.gwtproject.safehtml.SafeHtml" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/forms/Forms.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/forms/Forms.gwt.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.chips.Chips" />
+  <inherits name="org.dominokit.domino.ui.dropdown.DropDown" />
+  <inherits name="org.dominokit.domino.ui.grid.Grid" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.keyboard.Keyboard" />
+  <inherits name="org.dominokit.domino.ui.loaders.Loaders" />
+  <inherits name="org.dominokit.domino.ui.modals.Modals" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.gwtproject.editor.Editor" />
+  <inherits name="org.gwtproject.i18n.NumberFormat" />
+  <inherits name="org.gwtproject.safehtml.SafeHtml" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/grid/Grid.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/grid/Grid.gwt.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/header/Header.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/header/Header.gwt.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/icons/Icons.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/icons/Icons.gwt.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="">
+    <exclude name="package-info.java" />
+  </source>
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/infoboxes/InfoBoxes.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/infoboxes/InfoBoxes.gwt.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/keyboard/Keyboard.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/keyboard/Keyboard.gwt.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/labels/Labels.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/labels/Labels.gwt.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/layout/Layout.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/layout/Layout.gwt.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.grid.Grid" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.mediaquery.MediaQuery" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.themes.Themes" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/lists/Lists.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/lists/Lists.gwt.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.keyboard.Keyboard" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/loaders/Loaders.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/loaders/Loaders.gwt.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/media/Media.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/media/Media.gwt.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/mediaquery/MediaQuery.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/mediaquery/MediaQuery.gwt.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/modals/Modals.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/modals/Modals.gwt.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.grid.Grid" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.popover.Popover" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/notifications/Notifications.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/notifications/Notifications.gwt.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.animations.Animations" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/pagination/Pagination.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/pagination/Pagination.gwt.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.forms.Forms" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.keyboard.Keyboard" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/pickers/Pickers.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/pickers/Pickers.gwt.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/popover/Popover.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/popover/Popover.gwt.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.keyboard.Keyboard" />
+  <inherits name="org.dominokit.domino.ui.modals.Modals" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/preloaders/Preloaders.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/preloaders/Preloaders.gwt.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/progress/Progress.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/progress/Progress.gwt.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/scroll/Scroll.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/scroll/Scroll.gwt.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.button.Button" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/search/Search.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/search/Search.gwt.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.gwtproject.timer.Timer" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/sliders/Sliders.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/sliders/Sliders.gwt.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.grid.Grid" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.themes.Themes" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/spin/Spin.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/spin/Spin.gwt.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/splitpanel/SplitPanel.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/splitpanel/SplitPanel.gwt.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/stepper/Stepper.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/stepper/Stepper.gwt.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.animations.Animations" />
+  <inherits name="org.dominokit.domino.ui.button.Button" />
+  <inherits name="org.dominokit.domino.ui.forms.Forms" />
+  <inherits name="org.dominokit.domino.ui.grid.Grid" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.mediaquery.MediaQuery" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/steppers/Steppers.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/steppers/Steppers.gwt.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.animations.Animations" />
+  <inherits name="org.dominokit.domino.ui.collapsible.Collapsible" />
+  <inherits name="org.dominokit.domino.ui.mediaquery.MediaQuery" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/style/Style.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/style/Style.gwt.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.themes.Themes" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.gwtproject.timer.Timer" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/tabs/Tabs.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/tabs/Tabs.gwt.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.animations.Animations" />
+  <inherits name="org.dominokit.domino.ui.grid.Grid" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/tag/Tag.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/tag/Tag.gwt.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.chips.Chips" />
+  <inherits name="org.dominokit.domino.ui.dropdown.DropDown" />
+  <inherits name="org.dominokit.domino.ui.forms.Forms" />
+  <inherits name="org.dominokit.domino.ui.grid.Grid" />
+  <inherits name="org.dominokit.domino.ui.keyboard.Keyboard" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/themes/Themes.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/themes/Themes.gwt.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/thumbnails/Thumbnails.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/thumbnails/Thumbnails.gwt.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/timepicker/TimePicker.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/timepicker/TimePicker.gwt.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.animations.Animations" />
+  <inherits name="org.dominokit.domino.ui.button.Button" />
+  <inherits name="org.dominokit.domino.ui.forms.Forms" />
+  <inherits name="org.dominokit.domino.ui.grid.Grid" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.modals.Modals" />
+  <inherits name="org.dominokit.domino.ui.pickers.Pickers" />
+  <inherits name="org.dominokit.domino.ui.popover.Popover" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.gwtproject.i18n.CLDR" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/tree/Tree.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/tree/Tree.gwt.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.collapsible.Collapsible" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.search.Search" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/upload/Upload.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/upload/Upload.gwt.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.Typography.Typography" />
+  <inherits name="org.dominokit.domino.ui.grid.Grid" />
+  <inherits name="org.dominokit.domino.ui.icons.Icons" />
+  <inherits name="org.dominokit.domino.ui.notifications.Notifications" />
+  <inherits name="org.dominokit.domino.ui.popover.Popover" />
+  <inherits name="org.dominokit.domino.ui.progress.Progress" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.thumbnails.Thumbnails" />
+  <inherits name="org.dominokit.domino.ui.utils.Utils" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>

--- a/domino-ui/src/main/resources/org/dominokit/domino/ui/utils/Utils.gwt.xml
+++ b/domino-ui/src/main/resources/org/dominokit/domino/ui/utils/Utils.gwt.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2021 Dominokit
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<module>
+  <inherits name="org.gwtproject.core.Core" />
+  <inherits name="elemental2.svg.Svg" />
+  <inherits name="elemental2.core.Core" />
+  <inherits name="elemental2.dom.Dom" />
+  <inherits name="org.dominokit.domino.ui.collapsible.Collapsible" />
+  <inherits name="org.dominokit.domino.ui.forms.Forms" />
+  <inherits name="org.dominokit.domino.ui.popover.Popover" />
+  <inherits name="org.dominokit.domino.ui.style.Style" />
+  <inherits name="org.dominokit.domino.ui.tree.Tree" />
+  <inherits name="org.gwtproject.editor.Editor" />
+  <inherits name="org.gwtproject.i18n.NumberFormat" />
+  <inherits name="org.gwtproject.i18n.CLDR" />
+  <inherits name="org.gwtproject.safehtml.SafeHtml" />
+  <inherits name="org.gwtproject.timer.Timer" />
+  <inherits name="org.jboss.elemento.Core" />
+  <source path="" />
+</module>


### PR DESCRIPTION
I have generated a custom GWT module definition for each component. This makes it possible for users to use individual components rather than being forced to take all the components. Using individual components can reduce compile times, as GWT only compiles source that is actually referenced.

A further improvement would be to move the component CSS into public folders under each component. I have not done that in this pull request, as I wanted to keep it simple and focused on just the module definitions.

I think it would also be possible to remove some of the interdependencies between modules. For example, the Utils module (package) currently has dependencies on CLDR (~23MB jar), NumberFormat, Collapsible, Forms, Popover, Style and Tree. A dependency like Utils to Tree can be severed by moving `ParentTreeItem` out of Utils into Tree. This would be a breaking change, so I have not made it or any other code changes.

The biggest culprit in terms of compile times is the reference to the CLDR. It adds ~15 seconds to each compilation on my machine. It might be worth breaking the connection (e.g. with your own interfaces and adapters) to make the CLDR optional.