### PR TITLE
switch button change handler is fired twice

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/forms/NumberBox.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/forms/NumberBox.java
@@ -131,7 +131,11 @@ public abstract class NumberBox<T extends NumberBox<T, E>, E extends Number>
   @Override
   protected void doSetValue(E value) {
     if (nonNull(value)) {
-      getInputElement().element().value = getNumberFormat().format(value);
+      if (this.formattingEnabled) {
+        getInputElement().element().value = getNumberFormat().format(value);
+      } else {
+        getInputElement().element().value = String.valueOf(value);
+      }
     } else {
       getInputElement().element().value = "";
     }

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/forms/SwitchButton.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/forms/SwitchButton.java
@@ -146,7 +146,6 @@ public class SwitchButton extends AbstractValueBox<SwitchButton, HTMLElement, Bo
   /** {@inheritDoc} */
   @Override
   public SwitchButton value(Boolean value) {
-    super.value(value);
     if (value != null && value) {
       check();
     } else {


### PR DESCRIPTION
```
SwitchButton switchButton = SwitchButton.create();
// Show the change handler is fired twice by every setValue call.
switchButton.addChangeHandler(value -> DomGlobal.console.log(value));
switchButton.setValue(Boolean.TRUE);
switchButton.setValue(Boolean.FALSE);
DomGlobal.document.body.appendChild(switchButton.element());
```

SwtichButton change handler is always called twice by a setValue call. This is because the change handler is also fired by involving the super.value(value).

After inspecting the super.value call, it seems that it is safe to remove it, since the most code inside super.value is not relevant for SwitchButton. But to be honest, I am not 100% sure. Maybe a better solution is remove the super.value, but involve some part of codes inside the super call.
