### PR TITLE
fix label floating after setReadOnly called with true and false

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/forms/ValueBox.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/forms/ValueBox.java
@@ -878,7 +878,7 @@ public abstract class ValueBox<T extends ValueBox<T, E, V>, E extends HTMLElemen
     if (readOnly) {
       getInputElement().setAttribute(DISABLED, "true");
       getInputElement().setAttribute("readonly", "true");
-      getInputElement().setAttribute(FLOATING, isFloating());
+      getInputElement().setAttribute(FLOATING, permaFloating);
       css("readonly");
       floating();
     } else {
@@ -889,7 +889,7 @@ public abstract class ValueBox<T extends ValueBox<T, E, V>, E extends HTMLElemen
       if (getInputElement().hasAttribute(FLOATING)) {
         floating = Boolean.parseBoolean(getInputElement().getAttribute(FLOATING));
       } else {
-        floating = isFloating();
+        floating = permaFloating;
       }
       setFloating(floating);
       changeLabelFloating();


### PR DESCRIPTION
example:

valueBox.setReadOnly(true).setReadOnly(false) - and label floating always