### PR TITLE
Make total count public readable

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/pagination/BasePagination.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/pagination/BasePagination.java
@@ -200,6 +200,12 @@ public abstract class BasePagination<T extends BasePagination<T>>
 
   /** {@inheritDoc} */
   @Override
+  public int getTotalCount() {
+    return this.totalCount;
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public T setPageSize(int pageSize) {
     this.pageSize = pageSize;
     return (T) this;

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/pagination/HasPagination.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/pagination/HasPagination.java
@@ -136,6 +136,9 @@ public interface HasPagination {
    */
   HasPagination updatePagesByTotalCount(int totalCount, int pageSize);
 
+  /** @return the total number of items */
+  int getTotalCount();
+
   /**
    * Sets the page size
    *


### PR DESCRIPTION
The `HasPagination` interface supports `updatePagesByTotalCount(totalCount)`, can we have this total count public readable?