### PR TITLE
DataTable & Grouping plugin improvements

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/datatable/DataTable.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/datatable/DataTable.java
@@ -126,6 +126,10 @@ public class DataTable<T> extends BaseDominoElement<HTMLDivElement, DataTable<T>
     init();
   }
 
+  public DataStore<T> getDataStore() {
+    return dataStore;
+  }
+
   private DataTable<T> init() {
     tableConfig
         .getPlugins()

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/datatable/TableRow.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/datatable/TableRow.java
@@ -134,6 +134,10 @@ public class TableRow<T> extends BaseDominoElement<HTMLTableRowElement, TableRow
     return record;
   }
 
+  public DataTable<T> getDataTable() {
+    return dataTable;
+  }
+
   @Override
   public void addSelectionHandler(SelectionHandler<T> selectionHandler) {
     this.selectionHandlers.add(selectionHandler);

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/datatable/plugins/GroupingPlugin.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/datatable/plugins/GroupingPlugin.java
@@ -164,7 +164,9 @@ public class GroupingPlugin<T> implements DataTablePlugin<T>, TableConfig.RowApp
     }
   }
 
-  public class DataGroup<T> {
+  public static class DataGroup<T> implements TableRow.RowMetaObject {
+
+    private static final String KEY = "dataGroup";
 
     private List<TableRow<T>> groupRows = new ArrayList<>();
     private TableRow<T> lastRow;
@@ -176,7 +178,11 @@ public class GroupingPlugin<T> implements DataTablePlugin<T>, TableConfig.RowApp
     public DataGroup(TableRow<T> lastRow, CellRenderer.CellInfo<T> cellInfo) {
       this.lastRow = lastRow;
       this.cellInfo = cellInfo;
-      groupRows.add(lastRow);
+      addRow(lastRow);
+    }
+
+    public static <T> DataGroup<T> fromRow(TableRow<T> tableRow) {
+      return tableRow.getMetaObject(KEY);
     }
 
     public void toggleGroup() {
@@ -186,6 +192,7 @@ public class GroupingPlugin<T> implements DataTablePlugin<T>, TableConfig.RowApp
 
     public void addRow(TableRow<T> tableRow) {
       groupRows.add(tableRow);
+      tableRow.addMetaObject(this);
     }
 
     private DataGroup<T> setGroupIconSupplier(BaseIcon<?> groupIconSupplier) {
@@ -200,6 +207,11 @@ public class GroupingPlugin<T> implements DataTablePlugin<T>, TableConfig.RowApp
     private DataGroup<T> setGroupRenderer(CellRenderer<T> groupRenderer) {
       this.groupRenderer = groupRenderer;
       return this;
+    }
+
+    @Override
+    public String getKey() {
+      return KEY;
     }
 
     public void render() {


### PR DESCRIPTION
* add public DataTable.getDataStore method
* add public TableRow.getDataTable method
* implements RowMetaObject in DataGroup and add MetaObject with corresponding DataGroup to TableRow. 
* add static method DataGroup.fromRow. example usage (in grid editor onchange ): 
```
DataGroup.fromRow(cell.getTableRow()).render();
```