### PR TITLE
Tree/TreeItem enhancement

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/tree/Tree.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/tree/Tree.java
@@ -468,7 +468,7 @@ public class Tree<T> extends BaseDominoElement<HTMLDivElement, Tree<T>>
   /** {@inheritDoc} */
   @Override
   public List<TreeItem<T>> getSubItems() {
-    return new ArrayList<>(subItems);
+    return subItems;
   }
 
   /** {@inheritDoc} */
@@ -580,6 +580,12 @@ public class Tree<T> extends BaseDominoElement<HTMLDivElement, Tree<T>>
     }
 
     return activeValues;
+  }
+
+  /** Clear all direct children of the tree, effectively reset the tree */
+  public void clear() {
+    subItems.stream().forEach(TreeItem::clear);
+    subItems.clear();
   }
 
   /** {@inheritDoc} */

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/tree/TreeItem.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/tree/TreeItem.java
@@ -776,7 +776,7 @@ public class TreeItem<T> extends WavesElement<HTMLLIElement, TreeItem<T>>
   /** @return the list of all sub {@link TreeItem} */
   @Override
   public List<TreeItem<T>> getSubItems() {
-    return new ArrayList<>(subItems);
+    return subItems;
   }
 
   /** Selects this item, the item will be shown and activated */
@@ -796,6 +796,14 @@ public class TreeItem<T> extends WavesElement<HTMLLIElement, TreeItem<T>>
    */
   public void setValue(T value) {
     this.value = value;
+  }
+
+  /** Clear all direct children of the item, also remove the item element from the DOM tree */
+  public void clear() {
+    subItems.stream().forEach(TreeItem::clear);
+    subItems.clear();
+
+    super.remove();
   }
 
   /** {@inheritDoc} */


### PR DESCRIPTION
1) It is not efficient to create a copy of subItems by a getter. If copy is needed, it should be created by the one, which calls the getter.
2) Add clear method to Tree/TreeItem, which can be used to reset a Tree.