### PR TITLE
Breadcrumb enhancement

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/breadcrumbs/Breadcrumb.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/breadcrumbs/Breadcrumb.java
@@ -86,8 +86,7 @@ public class Breadcrumb extends BaseDominoElement<HTMLOListElement, Breadcrumb>
    */
   public Breadcrumb appendChild(String text, EventListener onClick) {
     BreadcrumbItem item = BreadcrumbItem.create(text);
-    addNewItem(item);
-    setActiveItem(item);
+    addAndActivateNewItem(item);
     item.addClickListener(onClick);
     return this;
   }
@@ -102,20 +101,27 @@ public class Breadcrumb extends BaseDominoElement<HTMLOListElement, Breadcrumb>
    */
   public Breadcrumb appendChild(BaseIcon<?> icon, String text, EventListener onClick) {
     BreadcrumbItem item = BreadcrumbItem.create(icon, text);
-    addNewItem(item);
-    setActiveItem(item);
+    addAndActivateNewItem(item);
     item.addClickListener(onClick);
     return this;
+  }
+
+  public Breadcrumb appendChild(BreadcrumbItem... items) {
+    return appendChild(false, items);
   }
 
   /**
    * Adds new location by providing {@link BreadcrumbItem}
    *
+   * @param silent boolean, if true dont trigger change handlers
    * @param items the {@link BreadcrumbItem} location to be added
    * @return same instance
    */
-  public Breadcrumb appendChild(BreadcrumbItem... items) {
-    addNewItems(items);
+  public Breadcrumb appendChild(boolean silent, BreadcrumbItem... items) {
+    for (BreadcrumbItem item : items) {
+      addNewItem(item);
+    }
+    setActiveItem(this.items.get(this.items.size() - 1), silent);
     return this;
   }
 
@@ -126,8 +132,7 @@ public class Breadcrumb extends BaseDominoElement<HTMLOListElement, Breadcrumb>
    * @return same instance
    */
   public Breadcrumb appendChild(BreadcrumbItem item) {
-    addNewItem(item);
-    setActiveItem(item);
+    addAndActivateNewItem(item);
     return this;
   }
 
@@ -174,11 +179,9 @@ public class Breadcrumb extends BaseDominoElement<HTMLOListElement, Breadcrumb>
     return allowNavigation;
   }
 
-  private void addNewItems(BreadcrumbItem... items) {
-    for (BreadcrumbItem item : items) {
-      addNewItem(item);
-    }
-    setActiveItem(this.items.get(this.items.size() - 1));
+  private void addAndActivateNewItem(BreadcrumbItem item) {
+    addNewItem(item);
+    setActiveItem(item);
   }
 
   private void addNewItem(BreadcrumbItem item) {

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/breadcrumbs/Breadcrumb.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/breadcrumbs/Breadcrumb.java
@@ -136,9 +136,10 @@ public class Breadcrumb extends BaseDominoElement<HTMLOListElement, Breadcrumb>
    *
    * @param itemFromIndex the {@link BreadcrumbItem} index from which and all its siblings are
    *     removed.
+   * @param silent boolean, if true dont trigger change handlers
    * @return same instance
    */
-  public Breadcrumb removeChildFrom(int itemFromIndex) {
+  public Breadcrumb removeChildFrom(int itemFromIndex, boolean silent) {
     List<BreadcrumbItem> removedItems = items.subList(itemFromIndex, items.size());
     removedItems.forEach(BaseDominoElement::remove);
 
@@ -146,7 +147,7 @@ public class Breadcrumb extends BaseDominoElement<HTMLOListElement, Breadcrumb>
 
     if (activeItem != null && !items.contains(activeItem)) {
       if (items.isEmpty()) activeItem = null;
-      else setActiveItem(items.get(items.size() - 1));
+      else setActiveItem(items.get(items.size() - 1), silent);
     }
 
     return this;
@@ -192,13 +193,18 @@ public class Breadcrumb extends BaseDominoElement<HTMLOListElement, Breadcrumb>
             });
   }
 
+  public Breadcrumb setActiveItem(BreadcrumbItem item) {
+    return setActiveItem(item, false);
+  }
+
   /**
    * Set a given item as the active item of the breadcrumb
    *
    * @param item The item be set as active one
+   * @param silent boolean, if true dont trigger change handlers
    * @return same instance
    */
-  public Breadcrumb setActiveItem(BreadcrumbItem item) {
+  public Breadcrumb setActiveItem(BreadcrumbItem item, boolean silent) {
     // If item is already active, do nothing here.
     if (item.isActive()) return this;
 
@@ -213,7 +219,7 @@ public class Breadcrumb extends BaseDominoElement<HTMLOListElement, Breadcrumb>
       }
     }
 
-    changeHandlers.forEach(changeHandler -> changeHandler.onValueChanged(activeItem));
+    if (!silent) changeHandlers.forEach(changeHandler -> changeHandler.onValueChanged(activeItem));
 
     return this;
   }

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/breadcrumbs/Breadcrumb.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/breadcrumbs/Breadcrumb.java
@@ -106,6 +106,12 @@ public class Breadcrumb extends BaseDominoElement<HTMLOListElement, Breadcrumb>
     return this;
   }
 
+  /**
+   * Adds new location by providing {@link BreadcrumbItem}, change handler can be triggered
+   *
+   * @param items the {@link BreadcrumbItem} location to be added
+   * @return same instance
+   */
   public Breadcrumb appendChild(BreadcrumbItem... items) {
     return appendChild(false, items);
   }
@@ -196,6 +202,12 @@ public class Breadcrumb extends BaseDominoElement<HTMLOListElement, Breadcrumb>
             });
   }
 
+  /**
+   * Set a given item as the active item of the breadcrumb, change handler can be triggered
+   *
+   * @param item The item be set as active one
+   * @return same instance
+   */
   public Breadcrumb setActiveItem(BreadcrumbItem item) {
     return setActiveItem(item, false);
   }

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/breadcrumbs/BreadcrumbItem.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/breadcrumbs/BreadcrumbItem.java
@@ -104,7 +104,7 @@ public class BreadcrumbItem extends BaseDominoElement<HTMLLIElement, BreadcrumbI
    *
    * @return same instance
    */
-  protected BreadcrumbItem activate() {
+  BreadcrumbItem activate() {
     if (!active) {
       element.addCss(BreadcrumbStyles.ACTIVE);
       textElement.remove();
@@ -125,7 +125,7 @@ public class BreadcrumbItem extends BaseDominoElement<HTMLLIElement, BreadcrumbI
    *
    * @return same instance
    */
-  protected BreadcrumbItem deActivate() {
+  BreadcrumbItem deActivate() {
     if (active) {
       element.removeCss(BreadcrumbStyles.ACTIVE);
       textElement.remove();
@@ -144,6 +144,8 @@ public class BreadcrumbItem extends BaseDominoElement<HTMLLIElement, BreadcrumbI
   /**
    * If true, sets the status to active, otherwise sets the status to inactive
    *
+   * @deprecated This method should be no longer used directly. Use {@link
+   *     Breadcrumb#setActiveItem(BreadcrumbItem)} instead
    * @param active the boolean to set the status
    * @return same instance
    */

--- a/domino-ui/src/main/java/org/dominokit/domino/ui/breadcrumbs/BreadcrumbItem.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/breadcrumbs/BreadcrumbItem.java
@@ -57,11 +57,11 @@ public class BreadcrumbItem extends BaseDominoElement<HTMLLIElement, BreadcrumbI
   private BaseIcon<?> icon;
   private boolean active = false;
 
-  private BreadcrumbItem(String text) {
+  protected BreadcrumbItem(String text) {
     init(text, null);
   }
 
-  private BreadcrumbItem(String text, BaseIcon<?> icon) {
+  protected BreadcrumbItem(String text, BaseIcon<?> icon) {
     init(text, icon);
   }
 
@@ -104,7 +104,7 @@ public class BreadcrumbItem extends BaseDominoElement<HTMLLIElement, BreadcrumbI
    *
    * @return same instance
    */
-  public BreadcrumbItem activate() {
+  protected BreadcrumbItem activate() {
     if (!active) {
       element.addCss(BreadcrumbStyles.ACTIVE);
       textElement.remove();
@@ -125,7 +125,7 @@ public class BreadcrumbItem extends BaseDominoElement<HTMLLIElement, BreadcrumbI
    *
    * @return same instance
    */
-  public BreadcrumbItem deActivate() {
+  protected BreadcrumbItem deActivate() {
     if (active) {
       element.removeCss(BreadcrumbStyles.ACTIVE);
       textElement.remove();
@@ -147,6 +147,7 @@ public class BreadcrumbItem extends BaseDominoElement<HTMLLIElement, BreadcrumbI
    * @param active the boolean to set the status
    * @return same instance
    */
+  @Deprecated
   public BreadcrumbItem setActive(boolean active) {
     if (active) {
       return activate();


### PR DESCRIPTION
1) Add removeChildFrom method, which allows you reset a Breadcrumb from a certain child.
2) Since removeChildFrom method is added, in method addNewItems, setActiveItem should be called on the last index of this.items, not items.
3) Change LinkedList to ArrayList for better random access on child items, do not see any reason why LinkedList is used before.
4) Breadcrumb is featured with HasChangeHandlers, to notify any active BreadcrumbItem change, before there is no way to detect it.
5) Due to new HasChangeHandlers feature:
	a) setActive method in Breadcrumb is public now
	b) setActive method in BreadcrumbItem deprecated, since you should call via the Breadcrumb to notify changeHandlers.
	c) active and deActive in BreadcrumbItem are protected now, they should being called only from Breadcrumb, not from outside world.
6) Some efficient enhancements like.
	a) setActiveItem call is removed from addNewItem, otherwise not efficient by using addNewItems, since it should be called there only once.
	b) Remove duplicated call on item.activate() in setActiveItem method of Breadcrumb
7) Make BreadcrumbItem constructor protected, so that it can be extended.
