### PR TITLE
improve SummaryPluginConfig

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/datatable/plugins/summary/SummaryPluginConfig.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/datatable/plugins/summary/SummaryPluginConfig.java
@@ -19,7 +19,15 @@ import org.dominokit.domino.ui.datatable.plugins.PluginConfig;
 
 public class SummaryPluginConfig implements PluginConfig {
 
-  private boolean removeOnEmptyData = false;
+  private boolean removeOnEmptyData;
+
+  public SummaryPluginConfig() {
+    this(false);
+  }
+
+  public SummaryPluginConfig(boolean removeOnEmptyData) {
+    this.removeOnEmptyData = removeOnEmptyData;
+  }
 
   /**
    * @return boolean, true will cause the plugin to remove the summary records for empty data


### PR DESCRIPTION
Add a new constructor:

```
  public SummaryPluginConfig(boolean removeOnEmptyData) {
    this.removeOnEmptyData = removeOnEmptyData;
  }
```

This new constructor will save a few lines of code. Instead of writing:

```
    SummaryPlugin<AngebotPositionListCompositeComponent, AngebotSummaryModel> pluginSummary = new SummaryPlugin<>();
    SummaryPluginConfig config = new SummaryPluginConfig();
    config.setRemoveOnEmptyData(true);
    pluginSummary.setConfig(config);
```
you can use:

```
    SummaryPlugin<AngebotPositionListCompositeComponent, AngebotSummaryModel> pluginSummary = new SummaryPlugin<>();
    pluginSummary.setConfig(new SummaryPluginConfig(true));
```