### PR TITLE
gFix in the setMessage method of MessageDialo

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/dialogs/MessageDialog.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/dialogs/MessageDialog.java
@@ -130,8 +130,7 @@ public class MessageDialog extends AbstractDialog<MessageDialog> {
    * @return Current instance for chaining
    */
   public MessageDialog setMessage(String message) {
-    messageElement.remove();
-    appendChild(messageElement.get().setTextContent(message));
+    messageElement.get().setTextContent(message);
     return this;
   }
 


### PR DESCRIPTION
Since messageElement is already a child of contentElement, calling appendChild directly is incorrect.