### PR TITLE
Fix LocalListScrollingDataSource search filter

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/datatable/store/LocalListScrollingDataSource.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/datatable/store/LocalListScrollingDataSource.java
@@ -479,4 +479,13 @@ public class LocalListScrollingDataSource<T>
                 isNull(this.lastSearch) || getSearchFilter().filterRecord(this.lastSearch, record))
         .collect(Collectors.toList());
   }
+
+  @Override
+  public List<T> filterData(Collection<T> data) {
+    return HasDataFilters.super.filterData(data).stream()
+        .filter(
+            record ->
+                isNull(this.lastSearch) || getSearchFilter().filterRecord(this.lastSearch, record))
+        .collect(Collectors.toList());
+  }
 }


### PR DESCRIPTION
fixes #1113 
filterData(Collection<>) was missing in LocalListScrollingDataSource