### PR TITLE
Bug fix: incorrect oldValue in InputFieldInitializer

### DIFF
--- a/domino-ui/src/main/java/org/dominokit/domino/ui/forms/InputFieldInitializer.java
+++ b/domino-ui/src/main/java/org/dominokit/domino/ui/forms/InputFieldInitializer.java
@@ -77,6 +77,7 @@ public class InputFieldInitializer<T extends FormElement<T, V>, V, E extends HTM
    */
   public InputFieldInitializer<T, V, E> init(HasInputElement<T, E> hasInput) {
     DominoElement<E> inputElement = hasInput.getInputElement();
+    inputElement.addEventListener("focus", evt -> oldValue = formElement.getValue());
     inputElement.addEventListener(
         "change",
         evt -> {


### PR DESCRIPTION
When setValue (with either silent = true or false) is called on a formElement, the oldValue in InputFieldInitializer is not updated correctly. This can later lead to an incorrect oldValue being passed to formElement.triggerChangeListeners.

```
        TextBox box = new TextBox();

        box.withValue("Start");

        box.addChangeListener((oldValue, newValue) -> {
            // Expected oldValue is "Start", but the current code returns null/empty.
            DomGlobal.console.log(oldValue + ", " + newValue);
        });

        Domino.body().appendChild(box);
```